### PR TITLE
Signing support [UserStory - As a WebWorks developer, I can sign my bar ...

### DIFF
--- a/lib/bbwp.js
+++ b/lib/bbwp.js
@@ -22,6 +22,7 @@ var path = require("path"),
     localize = require("./localize"),
     configParser = require("./config-parser"),
     packagerUtils = require("./packager-utils"),
+    packagerValidator = require("./packager-validator"),
     barBuilder = require("./bar-builder"),
     session;
 
@@ -29,6 +30,9 @@ try {
     cmdline.parse(process.argv);
     session = require("./session").initialize(cmdline);
 
+    //validate session Object
+    packagerValidator.validateSession(session);
+    
     //prepare files for webworks archiving
     logger.info(localize.translate("PROGRESS_FILE_POPULATING_SOURCE"));
     fileManager.prepareOutputFiles(session);

--- a/lib/cmdline.js
+++ b/lib/cmdline.js
@@ -19,8 +19,10 @@ var cmd = require("commander"),
 
 cmd
     .version('1.0.0.0')
-    .usage('[drive:][path]archive [-s [dir]] [[-gcsk cskpassword -gp12 p12password | -g genpassword] [-buildIdnum]] [-o dir] [-d]')
+    .usage('[drive:][path]archive [-s [dir]] [[ -g genpassword] [-buildId num]] [-o dir] [-d]')
     .option('-s, --source [dir]', 'Save source. The default behaviour is to not save the source files. If dir is specified then creates dir\\src\\ directory structure. If no dir specified then the path of archive is assumed')
+    .option('-g, --password <password>', 'Signing key password')
+    .option('-b, --buildId <num>', 'Specifies the build number for signing (typically incremented from previous signing).')
     .option('-o, --output <dir>', 'Redirects output file location to dir. If both -o and dir are not specified then the path of archive is assumed')
     .option('-d, --debug', 'Allows use of not signed build on device by utilizing debug token and enables Web Inspector.')
     .option('-v, --verbose', 'Turn on verbose messages');

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -22,6 +22,9 @@ var Localize = require("localize"),
         "EXCEPTION_WIDGET_ARCHIVE_NOT_FOUND": {
             "en": "Failed to find WebWorks archive: $[1]"
         },
+        "EXCEPTION_MISSING_SIGNING_KEYS": {
+            "en": "Cannot sign application - failed to find signing keys"
+        },
         "EXCEPTION_DEBUG_TOKEN_NOT_FOUND": {
             "en": "Failed to find debug token"
         },

--- a/lib/native-packager.js
+++ b/lib/native-packager.js
@@ -88,6 +88,9 @@ function generateOptionsFile(session, target) {
         }
     }
     
+    //TODO add logic to use proper buildId (i.e. -buildId or 4rth octet in version)
+    //getBuildId();
+    
     //Signing params
     if (target === "device" && session.keystore && session.storepass && session.buildId) {
         optionsStr += "-sign" + NL;

--- a/lib/native-packager.js
+++ b/lib/native-packager.js
@@ -136,7 +136,13 @@ function execNativePackager(session, callback) {
     });
 
     nativePkgr.stdout.on("data", function (data) {
-        logger.info(data.toString());
+        msg = data.toString();
+        
+        if (msg.toLowerCase().indexOf("error:") >= 0) {
+            logger.error(msg);
+        } else {
+            logger.info(msg);
+        }
     });
 
     nativePkgr.stderr.on("data", function (data) {

--- a/lib/native-packager.js
+++ b/lib/native-packager.js
@@ -88,6 +88,17 @@ function generateOptionsFile(session, target) {
         }
     }
     
+    //Signing params
+    if (target === "device" && session.keystore && session.storepass && session.buildId) {
+        optionsStr += "-sign" + NL;
+        optionsStr += "-keystore" + NL;
+        optionsStr += session.keystore + NL;
+        optionsStr += "-storepass" + NL;
+        optionsStr += session.storepass + NL;
+        optionsStr += "-buildId" + NL;
+        optionsStr += session.buildId + NL;
+    }
+    
     optionsStr += path.resolve(util.format(session.barPath, target)) + NL;
     optionsStr += "-C" + NL;
     optionsStr += session.sourceDir + NL;

--- a/lib/packager-validator.js
+++ b/lib/packager-validator.js
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2012 Research In Motion Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */ 
+var check = require('validator').check,
+    sanitize = require('validator').sanitize,
+    localize = require("./localize"),
+    logger = require("./logger"),
+    signingHelper = require("./signing-helper"),
+    _self;
+    
+//NOTE this class is unfinished and is a work in progress
+    
+_self = {
+    //TODO create one global validate method that will validate
+    //both the session and configObj?
+    validateSession: function (session) {
+        //If -g <password> is set, but no keys were found, throw an error
+        //The string check is to get around a really weird issue in commander
+        //where when -g is not provided, the storepass comes in as a function...
+        if (session.storepass && typeof session.storepass === "string" && !session.keystore) {
+            throw localize.translate("EXCEPTION_MISSING_SIGNING_KEYS");
+        }
+    }
+};
+
+module.exports = _self;

--- a/lib/session.js
+++ b/lib/session.js
@@ -17,6 +17,7 @@
 var path = require("path"),
     wrench = require("wrench"),
     logger = require("./logger"),
+    signingHelper = require("./signing-helper"),
     barConf = require("./bar-conf");
 
 module.exports = {
@@ -24,7 +25,9 @@ module.exports = {
         var sourceDir,
             outputDir = cmdline.output,
             archivePath = path.resolve(cmdline.args[0]),
-            archiveName = path.basename(archivePath, '.zip');
+            archiveName = path.basename(archivePath, '.zip'),
+            signingPassword = cmdline.password,
+            buildId = cmdline.buildId;
 
         //If -o option was not provided, default output location is the same as .zip.
         outputDir = outputDir || path.dirname(archivePath);
@@ -35,7 +38,7 @@ module.exports = {
         } else {
             sourceDir = outputDir + "/src";
         }
-
+        
         if (!path.existsSync(sourceDir)) {
             wrench.mkdirSyncRecursive(sourceDir, "0755");
         }
@@ -61,6 +64,9 @@ module.exports = {
             "barPath": outputDir + "/%s/" + archiveName + ".bar",
             "verbose": !!cmdline.verbose,
             "debug": !!cmdline.debug,
+            "keystore": signingHelper.getKeyStorePath(),
+            "storepass": signingPassword,
+            "buildId": buildId,
             "targets": ["simulator", "device"] // TODO
         };
     }

--- a/lib/signing-helper.js
+++ b/lib/signing-helper.js
@@ -1,8 +1,21 @@
+/*
+ *  Copyright 2012 Research In Motion Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */ 
 var path = require('path'),
     os = require('os'),
-    localize = require("./localize"),
     authorP12 = "author.p12",
-    sigtoolP12 = "sigtool.p12",
     _self;
 
 function getKeyStoreDefaultPath() {
@@ -14,25 +27,23 @@ function getKeyStoreDefaultPath() {
     var p = "";
     if (os.type().toLowerCase().indexOf("windows") >= 0) {
         // Try Windows XP location
-        p = process.env.HOMEPATH + "\\Local Settings\\Application Data\\Research In Motion\\" + sigtoolP12;
+        p = process.env.HOMEPATH + "\\Local Settings\\Application Data\\Research In Motion\\" + authorP12;
         if (path.existsSync(p)) {
             return p;
         }
 
         // Try Windows Vista and Windows 7 location
-        p = process.env.HOMEPATH + "\\AppData\\Local\\Research In Motion\\" + sigtoolP12;
+        p = process.env.HOMEPATH + "\\AppData\\Local\\Research In Motion\\" + authorP12;
         if (path.existsSync(p)) {
             return p;
         }
     } else if (os.type().toLowerCase().indexOf("darwin") >= 0) {
         // Try Mac OS location
-        p = "~/Library/Research In Motion/" + sigtoolP12;
+        p = "~/Library/Research In Motion/" + authorP12;
         if (path.existsSync(p)) {
             return p;
         }
     }
-
-    throw localize.translate("EXCEPTION_MISSING_SIGNING_KEYS");
 }
 
 _self = {

--- a/lib/signing-helper.js
+++ b/lib/signing-helper.js
@@ -1,0 +1,45 @@
+var path = require('path'),
+    os = require('os'),
+    localize = require("./localize"),
+    authorP12 = "author.p12",
+    sigtoolP12 = "sigtool.p12",
+    _self;
+
+function getKeyStoreDefaultPath() {
+    // The default location where keystore is will vary based on the OS:
+    // Windows XP: %HOMEPATH%\Local Settings\Application Data\Research In Motion
+    // Windows Vista and Windows 7: %HOMEPATH%\AppData\Local\Research In Motion
+    // Mac OS: ~/Library/Research In Motion
+    // UNIX or Linux: ~/.rim
+    var p = "";
+    if (os.type().toLowerCase().indexOf("windows") >= 0) {
+        // Try Windows XP location
+        p = process.env.HOMEPATH + "\\Local Settings\\Application Data\\Research In Motion\\" + sigtoolP12;
+        if (path.existsSync(p)) {
+            return p;
+        }
+
+        // Try Windows Vista and Windows 7 location
+        p = process.env.HOMEPATH + "\\AppData\\Local\\Research In Motion\\" + sigtoolP12;
+        if (path.existsSync(p)) {
+            return p;
+        }
+    } else if (os.type().toLowerCase().indexOf("darwin") >= 0) {
+        // Try Mac OS location
+        p = "~/Library/Research In Motion/" + sigtoolP12;
+        if (path.existsSync(p)) {
+            return p;
+        }
+    }
+
+    throw localize.translate("EXCEPTION_MISSING_SIGNING_KEYS");
+}
+
+_self = {
+    getKeyStorePath : function () {
+        // Todo: decide where to put sigtool.p12 which is genereated and used in WebWorks SDK for Tablet OS
+        return getKeyStoreDefaultPath();
+    }
+};
+
+module.exports = _self;

--- a/lib/signing-helper.js
+++ b/lib/signing-helper.js
@@ -39,7 +39,7 @@ function getKeyStoreDefaultPath() {
         }
     } else if (os.type().toLowerCase().indexOf("darwin") >= 0) {
         // Try Mac OS location
-        p = "~/Library/Research In Motion/" + authorP12;
+        p = process.env.HOME + "/Library/Research In Motion/" + authorP12;
         if (path.existsSync(p)) {
             return p;
         }

--- a/test/unit/lib/cmdline.js
+++ b/test/unit/lib/cmdline.js
@@ -38,4 +38,14 @@ describe("Command line", function () {
         cmd.parseOptions(["-v"]);
         expect(cmd.verbose).toBeTruthy();
     });
+    
+    it("accepts -g with argument", function () {
+        cmd.parseOptions(["-g", "myPassword"]);
+        expect(cmd.password).toEqual("myPassword");
+    });
+    
+    it("accepts --buildId with argument", function () {
+        cmd.parseOptions(["--buildId", "100"]);
+        expect(cmd.buildId).toEqual("100");
+    });
 });

--- a/test/unit/lib/packager-validator.js
+++ b/test/unit/lib/packager-validator.js
@@ -1,0 +1,18 @@
+var srcPath = __dirname + "/../../../lib/",
+    testData = require("./test-data"),
+    testUtilities = require("./test-utilities"),
+    localize = require(srcPath + "localize"),
+    packagerValidator = require(srcPath + "packager-validator"),
+    cmd;
+
+describe("Packager Validator", function () {
+    it("throws an exception when trying to sign and keys were not found", function () {
+        var session = testUtilities.cloneObj(testData.session);
+        session.storepass = "myPassword";
+        session.keystore = undefined;
+        
+        expect(function () {
+            packagerValidator.validateSession(session);
+        }).toThrow(localize.translate("EXCEPTION_MISSING_SIGNING_KEYS"));
+    });
+});

--- a/test/unit/lib/session.js
+++ b/test/unit/lib/session.js
@@ -42,4 +42,28 @@ describe("Session", function () {
         //src folder should be created in output directory
         expect(result.sourceDir).toEqual(path.join(path.dirname(zipLocation), "src"));
     });
+    
+    it("sets the password when specified using -g", function () {
+        var data = {
+            args: [ 'C:/sampleApp/sample.zip' ],
+            output: 'C:/sampleApp/bin',
+            source: 'C:/sampleApp/mySource',//equivalent to [-s C:/sampleApp/mySource]
+            password: 'myPassword'
+        },
+        result = session.initialize(data);
+        
+        expect(result.storepass).toEqual('myPassword');
+    });
+    
+    it("sets the buildId when specified [-buildId]", function () {
+        var data = {
+            args: [ 'C:/sampleApp/sample.zip' ],
+            output: 'C:/sampleApp/bin',
+            source: 'C:/sampleApp/mySource',//equivalent to [-s C:/sampleApp/mySource]
+            buildId: '100'
+        },
+        result = session.initialize(data);
+        
+        expect(result.buildId).toEqual('100');
+    });
 });

--- a/test/unit/lib/signing-helper.js
+++ b/test/unit/lib/signing-helper.js
@@ -31,11 +31,11 @@ describe("signing-helper", function () {
         spyOn(os, "type").andReturn("darwin");
         
         spyOn(path, "existsSync").andCallFake(function (path) {
-            return path.indexOf("~/Library/Research In Motion/") !== -1;
+            return path.indexOf("/Library/Research In Motion/") !== -1;
         });
         
         var result = signingHelper.getKeyStorePath();
-        expect(result).toContain("~/Library/Research In Motion/");
+        expect(result).toContain("/Library/Research In Motion/");
     });
     
     it("returns undefined on windows when keys cannot be found", function () {

--- a/test/unit/lib/signing-helper.js
+++ b/test/unit/lib/signing-helper.js
@@ -38,21 +38,19 @@ describe("signing-helper", function () {
         expect(result).toContain("~/Library/Research In Motion/");
     });
     
-    it("throws an exception on windows when keys cannot be found", function () {
+    it("returns undefined on windows when keys cannot be found", function () {
         spyOn(os, "type").andReturn("windows");
         spyOn(path, "existsSync").andReturn(false);
         
-        expect(function () {
-            signingHelper.getKeyStorePath();
-        }).toThrow(localize.translate("EXCEPTION_MISSING_SIGNING_KEYS"));
+        var result = signingHelper.getKeyStorePath();
+        expect(result).toBeUndefined();
     });
     
-    it("throws an exception on mac when keys cannot be found", function () {
+    it("returns undefined on mac when keys cannot be found", function () {
         spyOn(os, "type").andReturn("darwin");
         spyOn(path, "existsSync").andReturn(false);
         
-        expect(function () {
-            signingHelper.getKeyStorePath();
-        }).toThrow(localize.translate("EXCEPTION_MISSING_SIGNING_KEYS"));
+        var result = signingHelper.getKeyStorePath();
+        expect(result).toBeUndefined();
     });
 });

--- a/test/unit/lib/signing-helper.js
+++ b/test/unit/lib/signing-helper.js
@@ -1,0 +1,58 @@
+var testData = require('./test-data'),
+    signingHelper = require(testData.libPath + '/signing-helper'),
+    localize = require(testData.libPath + '/localize'),
+    path = require('path'),
+    os = require('os');
+
+describe("signing-helper", function () {
+    it("can find keys in windows Local Settings", function () {
+        spyOn(os, "type").andReturn("windows");
+        
+        spyOn(path, "existsSync").andCallFake(function (path) {
+            return path.indexOf("\\Local Settings") !== -1;
+        });
+        
+        var result = signingHelper.getKeyStorePath();
+        expect(result).toContain("\\Local Settings");
+    });
+    
+    it("can find keys in windows AppData", function () {
+        spyOn(os, "type").andReturn("windows");
+        
+        spyOn(path, "existsSync").andCallFake(function (path) {
+            return path.indexOf("\\AppData") !== -1;
+        });
+        
+        var result = signingHelper.getKeyStorePath();
+        expect(result).toContain("\\AppData");
+    });
+    
+    it("can find keys in the Mac Library folder", function () {
+        spyOn(os, "type").andReturn("darwin");
+        
+        spyOn(path, "existsSync").andCallFake(function (path) {
+            return path.indexOf("~/Library/Research In Motion/") !== -1;
+        });
+        
+        var result = signingHelper.getKeyStorePath();
+        expect(result).toContain("~/Library/Research In Motion/");
+    });
+    
+    it("throws an exception on windows when keys cannot be found", function () {
+        spyOn(os, "type").andReturn("windows");
+        spyOn(path, "existsSync").andReturn(false);
+        
+        expect(function () {
+            signingHelper.getKeyStorePath();
+        }).toThrow(localize.translate("EXCEPTION_MISSING_SIGNING_KEYS"));
+    });
+    
+    it("throws an exception on mac when keys cannot be found", function () {
+        spyOn(os, "type").andReturn("darwin");
+        spyOn(path, "existsSync").andReturn(false);
+        
+        expect(function () {
+            signingHelper.getKeyStorePath();
+        }).toThrow(localize.translate("EXCEPTION_MISSING_SIGNING_KEYS"));
+    });
+});


### PR DESCRIPTION
...file for distribution in AppWorld]

Unit tests have also been created.

Detailed list of changes:
-Updated command-line interface/session object to accept and store signing parameters from user
-Updated native packager call options file to include parameters to sign the bar (if specified)
-Error handling [Handle missing keys]
-Signing-helper class created to get signing key location (Per Eric Li)

Comments were lost due to moving the repo to blackberry
https://github.com/blackberry/BB10-Webworks-Packager/pull/76
