### PR TITLE
Place assets in blackbery-tablet.xml

### DIFF
--- a/lib/native-packager.js
+++ b/lib/native-packager.js
@@ -12,7 +12,6 @@ var childProcess = require("child_process"),
     
 function generateTabletXMLFile(session, config) {
     var files = wrench.readdirSyncRecursive(session.sourceDir),
-        obj,
         xmlObject = {
             id : config.id,
             name : config.name,
@@ -36,18 +35,26 @@ function generateTabletXMLFile(session, config) {
         };
     
     if (files) {
-        files.forEach(function (f) {
-            if (path.extname(f) === '.so') {
-                obj = {
-                    _attr : { type : 'qnx/elf' },
-                    _value : f
-                };
-            } else {
-                obj = {
-                    _value : f,
-                };
+        files.forEach(function (file) {
+            file = path.resolve(session.sourceDir, file);
+
+            if (file.indexOf("blackberry-tablet.xml") < 0 && !fs.statSync(file).isDirectory()) {
+            
+                file.replace("\\", "/");
+                file = file.split("src/")[1];
+                                
+                if (path.extname(file) === ".so") {
+                    xmlObject.asset.push({
+                        _attr : { type : 'qnx/elf' },
+                        _value : file
+                    });
+
+                } else {
+                    xmlObject.asset.push({
+                        _value : file
+                    });
+                }
             }
-            xmlObject.asset.push(obj);
         });
     }
     

--- a/lib/native-packager.js
+++ b/lib/native-packager.js
@@ -11,28 +11,46 @@ var childProcess = require("child_process"),
     NL = pkgrUtils.isWindows() ? "\r\n" : "\n";
     
 function generateTabletXMLFile(session, config) {
-    var xmlObject = {
-        id : config.id,
-        name : config.name,
-        versionNumber : config.version,
-        author : config.author,
-        asset : {
-            _attr : { entry : 'true', type : 'qnx/elf' },
-            _value : 'wwe'
-        },
-        initialWindow : {
-            systemChrome : 'none',
-            transparent : 'true'
-        },
-        env : {
-            _attr : { value : '12', var : 'WEBKIT_NUMBER_OF_BACKINGSTORE_TILES'}
-        },
-        permission : {
-            _attr : { system : 'true'},
-            _value : 'run_native'
-        }
-    };
-
+    var files = wrench.readdirSyncRecursive(session.sourceDir),
+        obj,
+        xmlObject = {
+            id : config.id,
+            name : config.name,
+            versionNumber : config.version,
+            author : config.author,
+            asset : [{
+                _attr : { entry : 'true', type : 'qnx/elf' },
+                _value : 'wwe'
+            }],
+            initialWindow : {
+                systemChrome : 'none',
+                transparent : 'true'
+            },
+            env : {
+                _attr : { value : '12', var : 'WEBKIT_NUMBER_OF_BACKINGSTORE_TILES'}
+            },
+            permission : {
+                _attr : { system : 'true'},
+                _value : 'run_native'
+            }
+        };
+    
+    if (files) {
+        files.forEach(function (f) {
+            if (path.extname(f) === '.so') {
+                obj = {
+                    _attr : { type : 'qnx/elf' },
+                    _value : f
+                };
+            } else {
+                obj = {
+                    _value : f,
+                };
+            }
+            xmlObject.asset.push(obj);
+        });
+    }
+    
     //Add description element if specifed
     if (config.description) {
         xmlObject.description = config.description;

--- a/lib/native-packager.js
+++ b/lib/native-packager.js
@@ -39,16 +39,14 @@ function generateTabletXMLFile(session, config) {
             file = path.resolve(session.sourceDir, file);
 
             if (file.indexOf("blackberry-tablet.xml") < 0 && !fs.statSync(file).isDirectory()) {
-            
-                file.replace("\\", "/");
+                file = file.replace(/\\/g, "/");
                 file = file.split("src/")[1];
-                                
+                
                 if (path.extname(file) === ".so") {
                     xmlObject.asset.push({
                         _attr : { type : 'qnx/elf' },
                         _value : file
                     });
-
                 } else {
                     xmlObject.asset.push({
                         _value : file

--- a/test/unit/lib/native-packager.js
+++ b/test/unit/lib/native-packager.js
@@ -98,6 +98,8 @@ describe("Native packager", function () {
             "<versionNumber>" + config.version + "</versionNumber>" +
             "<author>" + config.author + "</author>" +
             "<asset entry=\"true\" type=\"qnx/elf\">wwe</asset>" +
+            "<asset>abc</asset>" +
+            "<asset>xyz</asset>" +            
             "<initialWindow><systemChrome>none</systemChrome><transparent>true</transparent></initialWindow>" +
             "<env value=\"12\" var=\"WEBKIT_NUMBER_OF_BACKINGSTORE_TILES\"></env>" +
             "<permission system=\"true\">run_native</permission>" +


### PR DESCRIPTION
Fixed execution attribute being preserved/created when bar is deployed on device. Fixes issue #45.
- Resources are now included in the blackberry-xml as assets.
- .so files are automatically added with content type Qnx/Elf for permission fix
- Updated native packager unit tests to reflect changes.
