### PR TITLE
Pull Req: Validating of widget packaging doesn't give a compilation error, if <feature> element is provided for access URI specified with "*"

### DIFF
--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -80,9 +80,9 @@ function processWidgetData(data, widgetConfig) {
             if (attribs) {
                 if (attribs.uri === "*") {
                     if (accessElement.feature) {
-                        featureArray = packagerUtils.isArray(accessElement.feature) ? accessElement.feature : [accessElement.feature];
-                        check(featureArray.feature, localize.translate("EXCEPTION_FEATURE_DEFINED_WITH_WILDCARD_ACCESS_URI")).notEmpty();
+                        throw localize.translate("EXCEPTION_FEATURE_DEFINED_WITH_WILDCARD_ACCESS_URI"); 
                     }
+                    
                     widgetConfig.hasMultiAccess = true;
                 } else {
                     //set features for this access list

--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -79,6 +79,10 @@ function processWidgetData(data, widgetConfig) {
 
             if (attribs) {
                 if (attribs.uri === "*") {
+                    if (accessElement.feature) {
+                        featureArray = packagerUtils.isArray(accessElement.feature) ? accessElement.feature : [accessElement.feature];
+                        check(featureArray.feature, localize.translate("EXCEPTION_FEATURE_DEFINED_WITH_WILDCARD_ACCESS_URI")).notEmpty();
+                    }
                     widgetConfig.hasMultiAccess = true;
                 } else {
                     //set features for this access list

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -71,7 +71,7 @@ var Localize = require("localize"),
             "en": "Icon src cannot be null"
         },
         "EXCEPTION_FEATURE_DEFINED_WITH_WILDCARD_ACCESS_URI": {
-            "en": "Invalid config.xml - no tags are allowed for this element"
+            "en": "Invalid config.xml - no <feature> tags are allowed for this <access> element"
         }
     }, "", ""); // TODO maybe a bug in localize, must set default locale to "" in order get it to work
 

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -69,8 +69,10 @@ var Localize = require("localize"),
         },
         "EXCEPTION_INVALID_ICON_SRC": {
             "en": "Icon src cannot be null"
+        },
+        "EXCEPTION_FEATURE_DEFINED_WITH_WILDCARD_ACCESS_URI": {
+            "en": "Invalid config.xml - no tags are allowed for this element"
         }
-        
     }, "", ""); // TODO maybe a bug in localize, must set default locale to "" in order get it to work
 
 loc.setLocale("en");

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -232,6 +232,30 @@ describe("xml parser", function () {
             } ]);
         });
     });
+
+    it("should fail when feature is defined with the uri being equal to *", function () {
+        var data = testUtilities.cloneObj(testData.xml2jsConfig);
+        data['access'] = {"@" : {"uri" : "*"}, "feature" : {"@": {"id": "blackberry.app"}}};
+
+        //console.log(data);
+
+        mockParsing(data);
+
+        expect(function () {
+            configParser.parse(configPath, session, function (configObj) {});
+        }).toThrow("Invalid config.xml - no tags are allowed for this element");
+    });
+
+    it("should fail when multi features are defined with the uri being equal to *", function () {
+        var data = testUtilities.cloneObj(testData.xml2jsConfig);
+        data['access'] = {"@" : {"uri" : "*"}, "feature" : {"@": {"id": "blackberry.app"}}, "feature" : {"@": {"id": "blackberry.system"}}, "feature" : {"@": {"id": "blackberry.invoke"}}};
+
+        mockParsing(data);
+
+        expect(function () {
+            configParser.parse(configPath, session, function (configObj) {});
+        }).toThrow("Invalid config.xml - no tags are allowed for this element");
+    });
     
     it("does not fail when there is a single feature element in the access list", function () {
         var data = testUtilities.cloneObj(testData.xml2jsConfig);

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -241,7 +241,7 @@ describe("xml parser", function () {
 
         expect(function () {
             configParser.parse(configPath, session, function (configObj) {});
-        }).toThrow("Invalid config.xml - no tags are allowed for this element");
+        }).toThrow(localize.translate("EXCEPTION_FEATURE_DEFINED_WITH_WILDCARD_ACCESS_URI"));
     });
 
     it("should fail when multi features are defined with the uri being equal to *", function () {
@@ -252,7 +252,7 @@ describe("xml parser", function () {
 
         expect(function () {
             configParser.parse(configPath, session, function (configObj) {});
-        }).toThrow("Invalid config.xml - no tags are allowed for this element");
+        }).toThrow(localize.translate("EXCEPTION_FEATURE_DEFINED_WITH_WILDCARD_ACCESS_URI"));
     });
     
     it("does not fail when there is a single feature element in the access list", function () {

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -237,8 +237,6 @@ describe("xml parser", function () {
         var data = testUtilities.cloneObj(testData.xml2jsConfig);
         data['access'] = {"@" : {"uri" : "*"}, "feature" : {"@": {"id": "blackberry.app"}}};
 
-        //console.log(data);
-
         mockParsing(data);
 
         expect(function () {
@@ -248,7 +246,7 @@ describe("xml parser", function () {
 
     it("should fail when multi features are defined with the uri being equal to *", function () {
         var data = testUtilities.cloneObj(testData.xml2jsConfig);
-        data['access'] = {"@" : {"uri" : "*"}, "feature" : {"@": {"id": "blackberry.app"}}, "feature" : {"@": {"id": "blackberry.system"}}, "feature" : {"@": {"id": "blackberry.invoke"}}};
+        data['access'] = {"@" : {"uri" : "*"}, "feature" : [{"@": {"id": "blackberry.app"}}, {"@": {"id": "blackberry.system"}}, {"@": {"id": "blackberry.invoke"}}]};
 
         mockParsing(data);
 


### PR DESCRIPTION
This pull request includes the bug fix & unit test for issue blackberry/BB10-Webworks-Packager#58
