### PR TITLE
Fixed bbwp being launched from different directory

### DIFF
--- a/bbwp
+++ b/bbwp
@@ -1,1 +1,3 @@
-./dependencies/node/node ./lib/bbwp.js $@
+#!/bin/sh
+BBWP_DIR=`dirname $0`
+$BBWP_DIR/dependencies/node/node $BBWP_DIR/lib/bbwp.js $@


### PR DESCRIPTION
Updated shell script to work when bbwp is executed and is not located in the current directory.

Fixes issue #71
