### PR TITLE
Pull Req: Include bar depdendencies to app at package time

### DIFF
--- a/lib/bar-builder.js
+++ b/lib/bar-builder.js
@@ -28,6 +28,7 @@ function buildTarget(previous, baton) {
     var target = this.session.targets[targetIdx++];
     wrench.mkdirSyncRecursive(this.session.outputDir + "/" + target);
     fileManager.copyWWE(this.session, target);
+    fileManager.copyBarDependencies(this.session, target);
     nativePkgr.exec(this.session, target, this.config, function (code) {
         if (code !== 0) {
             logger.error(localize.translate("EXCEPTION_NATIVEPACKAGER"));

--- a/lib/bar-builder.js
+++ b/lib/bar-builder.js
@@ -28,7 +28,7 @@ function buildTarget(previous, baton) {
     var target = this.session.targets[targetIdx++];
     wrench.mkdirSyncRecursive(this.session.outputDir + "/" + target);
     fileManager.copyWWE(this.session, target);
-    fileManager.copyBarDependencies(this.session, target);
+    fileManager.copyBarDependencies(this.session);
     nativePkgr.exec(this.session, target, this.config, function (code) {
         if (code !== 0) {
             logger.error(localize.translate("EXCEPTION_NATIVEPACKAGER"));

--- a/lib/bar-builder.js
+++ b/lib/bar-builder.js
@@ -28,7 +28,6 @@ function buildTarget(previous, baton) {
     var target = this.session.targets[targetIdx++];
     wrench.mkdirSyncRecursive(this.session.outputDir + "/" + target);
     fileManager.copyWWE(this.session, target);
-    fileManager.copyBarDependencies(this.session);
     nativePkgr.exec(this.session, target, this.config, function (code) {
         if (code !== 0) {
             logger.error(localize.translate("EXCEPTION_NATIVEPACKAGER"));

--- a/lib/bar-builder.js
+++ b/lib/bar-builder.js
@@ -28,7 +28,6 @@ function buildTarget(previous, baton) {
     var target = this.session.targets[targetIdx++];
     wrench.mkdirSyncRecursive(this.session.outputDir + "/" + target);
     fileManager.copyWWE(this.session, target);
-    fileManager.copyBarDependencies(this.session, target);
     nativePkgr.exec(this.session, target, this.config, function (code) {
         if (code !== 0) {
             logger.error(localize.translate("EXCEPTION_NATIVEPACKAGER"));

--- a/lib/bar-conf.js
+++ b/lib/bar-conf.js
@@ -20,6 +20,6 @@ self.ROOT = "";
 self.CHROME = self.ROOT + "/chrome";
 self.LIB = self.CHROME + "/lib";
 self.EXT = self.CHROME + "/ext";
-self.PLUGINS = self.CHROME + "/plugins";
+self.PLUGINS = self.ROOT + "/plugins";
 
 module.exports = self;

--- a/lib/bar-conf.js
+++ b/lib/bar-conf.js
@@ -20,5 +20,6 @@ self.ROOT = "";
 self.CHROME = self.ROOT + "/chrome";
 self.LIB = self.CHROME + "/lib";
 self.EXT = self.CHROME + "/ext";
+self.PLUGINS = self.CHROME + "/plugins";
 
 module.exports = self;

--- a/lib/bbwp.js
+++ b/lib/bbwp.js
@@ -32,6 +32,7 @@ try {
     //prepare files for webworks archiving
     logger.info(localize.translate("PROGRESS_FILE_POPULATING_SOURCE"));
     fileManager.prepareOutputFiles(session);
+    fileManager.copyBarDependencies(session);
 
     //parse config.xml
     logger.info(localize.translate("PROGRESS_SESSION_CONFIGXML"));

--- a/lib/bbwp.js
+++ b/lib/bbwp.js
@@ -32,7 +32,6 @@ try {
     //prepare files for webworks archiving
     logger.info(localize.translate("PROGRESS_FILE_POPULATING_SOURCE"));
     fileManager.prepareOutputFiles(session);
-    fileManager.copyBarDependencies(session);
 
     //parse config.xml
     logger.info(localize.translate("PROGRESS_SESSION_CONFIGXML"));

--- a/lib/conf.js
+++ b/lib/conf.js
@@ -26,6 +26,6 @@ module.exports = {
     DEPENDENCIES_TOOLS: path.normalize(__dirname + "/../dependencies/tools"),
     DEPENDENCIES_EMU: path.normalize(__dirname + "/../Framework/dependencies/BBX-Emulator"),
     DEPENDENCIES_WWE: path.normalize(__dirname + "/../dependencies/%s-wwe"),
-    DEPENDENCIES_BAR: path.normalize(__dirname + "/../dependencies/bar-dependencies"),
+    DEPENDENCIES_BAR: path.normalize(__dirname + "/../dependencies/bar-dependencies/%s"),
     DEBUG_TOKEN: path.normalize(__dirname + "/../debugtoken.bar")
 };

--- a/lib/conf.js
+++ b/lib/conf.js
@@ -26,5 +26,6 @@ module.exports = {
     DEPENDENCIES_TOOLS: path.normalize(__dirname + "/../dependencies/tools"),
     DEPENDENCIES_EMU: path.normalize(__dirname + "/../Framework/dependencies/BBX-Emulator"),
     DEPENDENCIES_WWE: path.normalize(__dirname + "/../dependencies/%s-wwe"),
+    DEPENDENCIES_BAR: path.normalize(__dirname + "/../dependencies/bar-dependencies"),
     DEBUG_TOKEN: path.normalize(__dirname + "/../debugtoken.bar")
 };

--- a/lib/file-manager.js
+++ b/lib/file-manager.js
@@ -77,6 +77,10 @@ function prepare(session) {
     unzip(session.archivePath, session.sourceDir);
 }
 
+function copyBarDependencies(session) {
+    wrench.copyDirSyncRecursive(conf.DEPENDENCIES_BAR, session.sourceDir);
+}
+
 function getModulesArray(dest, files, baseDir) {
     var modulesList = [];
 
@@ -117,14 +121,6 @@ function copyWWE(session, target) {
         dest = path.normalize(session.sourceDir + "/wwe");
 
     fs.copySync(src, dest);
-}
-
-function copyBarDependencies(session) {
-    var conf = session.conf,
-        src = path.normalize(conf.DEPENDENCIES_BAR),
-        dest = path.normalize(session.sourceDir);
-
-    wrench.copyDirSyncRecursive(src, dest);
 }
 
 function checkMissingFileInAPIFolder(apiDir, fileToCheck) {
@@ -185,9 +181,9 @@ module.exports = {
 
     copyWWE: copyWWE,
 
-    copyBarDependencies: copyBarDependencies,
-
     prepareOutputFiles: prepare,
+
+    copyBarDependencies: copyBarDependencies,
 
     copyExtensions: copyExtensions,
 

--- a/lib/file-manager.js
+++ b/lib/file-manager.js
@@ -66,13 +66,6 @@ function prepare(session) {
     // copy bootstrap
     wrench.copyDirSyncRecursive(conf.DEPENDENCIES_BOOTSTRAP, dest.CHROME);
 
-    if (!path.existsSync(dest.PLUGINS)) {
-        wrench.mkdirSyncRecursive(dest.PLUGINS, "0755");
-    }
-
-    // copy bar dependencies
-    this.copyBarDependencies(session);
-
     if (!path.existsSync(dest.LIB)) {
         wrench.mkdirSyncRecursive(dest.LIB, "0755");
     }
@@ -84,11 +77,6 @@ function prepare(session) {
     unzip(session.archivePath, session.sourceDir);
 }
 
-function copyBarDependencies(session) {
-    var conf = session.conf;
-    
-    wrench.copyDirSyncRecursive(conf.DEPENDENCIES_BAR, session.sourceDir);
-}
 
 function getModulesArray(dest, files, baseDir) {
     var modulesList = [];
@@ -130,6 +118,18 @@ function copyWWE(session, target) {
         dest = path.normalize(session.sourceDir + "/wwe");
 
     fs.copySync(src, dest);
+}
+
+function copyBarDependencies(session, target) {
+    var conf = session.conf,
+        src = path.normalize(util.format(conf.DEPENDENCIES_BAR, target)),
+        dest = path.normalize(session.sourcePaths.PLUGINS);
+
+    if (!path.existsSync(dest.PLUGINS)) {
+        wrench.mkdirSyncRecursive(dest.PLUGINS, "0755");
+    }
+    
+    wrench.copyDirSyncRecursive(src, session.sourcePaths.PLUGINS);
 }
 
 function checkMissingFileInAPIFolder(apiDir, fileToCheck) {
@@ -190,9 +190,9 @@ module.exports = {
 
     copyWWE: copyWWE,
 
-    prepareOutputFiles: prepare,
-
     copyBarDependencies: copyBarDependencies,
+
+    prepareOutputFiles: prepare,
 
     copyExtensions: copyExtensions,
 

--- a/lib/file-manager.js
+++ b/lib/file-manager.js
@@ -66,6 +66,13 @@ function prepare(session) {
     // copy bootstrap
     wrench.copyDirSyncRecursive(conf.DEPENDENCIES_BOOTSTRAP, dest.CHROME);
 
+    if (!path.existsSync(dest.PLUGINS)) {
+        wrench.mkdirSyncRecursive(dest.PLUGINS, "0755");
+    }
+
+    // copy bar dependencies
+    this.copyBarDependencies(session);
+
     if (!path.existsSync(dest.LIB)) {
         wrench.mkdirSyncRecursive(dest.LIB, "0755");
     }

--- a/lib/file-manager.js
+++ b/lib/file-manager.js
@@ -66,6 +66,13 @@ function prepare(session) {
     // copy bootstrap
     wrench.copyDirSyncRecursive(conf.DEPENDENCIES_BOOTSTRAP, dest.CHROME);
 
+    if (!path.existsSync(dest.PLUGINS)) {
+        wrench.mkdirSyncRecursive(dest.PLUGINS, "0755");
+    }
+
+    // copy bar dependencies
+    this.copyBarDependencies(session);
+
     if (!path.existsSync(dest.LIB)) {
         wrench.mkdirSyncRecursive(dest.LIB, "0755");
     }
@@ -75,6 +82,12 @@ function prepare(session) {
 
     // unzip archive
     unzip(session.archivePath, session.sourceDir);
+}
+
+function copyBarDependencies(session) {
+    var conf = session.conf;
+    
+    wrench.copyDirSyncRecursive(conf.DEPENDENCIES_BAR, session.sourceDir);
 }
 
 function getModulesArray(dest, files, baseDir) {
@@ -117,14 +130,6 @@ function copyWWE(session, target) {
         dest = path.normalize(session.sourceDir + "/wwe");
 
     fs.copySync(src, dest);
-}
-
-function copyBarDependencies(session, target) {
-    var conf = session.conf,
-        src = path.normalize(util.format(conf.DEPENDENCIES_BAR, target)),
-        dest = path.normalize(session.sourceDir);
-
-    wrench.copyDirSyncRecursive(src, dest);
 }
 
 function checkMissingFileInAPIFolder(apiDir, fileToCheck) {
@@ -185,9 +190,9 @@ module.exports = {
 
     copyWWE: copyWWE,
 
-    copyBarDependencies: copyBarDependencies,
-
     prepareOutputFiles: prepare,
+
+    copyBarDependencies: copyBarDependencies,
 
     copyExtensions: copyExtensions,
 

--- a/lib/file-manager.js
+++ b/lib/file-manager.js
@@ -78,6 +78,8 @@ function prepare(session) {
 }
 
 function copyBarDependencies(session) {
+    var conf = session.conf;
+    
     wrench.copyDirSyncRecursive(conf.DEPENDENCIES_BAR, session.sourceDir);
 }
 

--- a/lib/file-manager.js
+++ b/lib/file-manager.js
@@ -119,6 +119,14 @@ function copyWWE(session, target) {
     fs.copySync(src, dest);
 }
 
+function copyBarDependencies(session, target) {
+    var conf = session.conf,
+        src = path.normalize(util.format(conf.DEPENDENCIES_BAR, target)),
+        dest = path.normalize(session.sourceDir);
+
+    wrench.copyDirSyncRecursive(src, dest);
+}
+
 function checkMissingFileInAPIFolder(apiDir, fileToCheck) {
     if (!path.existsSync(apiDir + "/" + fileToCheck)) {
         throw localize.translate("EXCEPTION_MISSING_FILE_IN_API_DIR", fileToCheck, apiDir);
@@ -176,6 +184,8 @@ module.exports = {
     unzip: unzip,
 
     copyWWE: copyWWE,
+
+    copyBarDependencies: copyBarDependencies,
 
     prepareOutputFiles: prepare,
 

--- a/lib/file-manager.js
+++ b/lib/file-manager.js
@@ -119,9 +119,9 @@ function copyWWE(session, target) {
     fs.copySync(src, dest);
 }
 
-function copyBarDependencies(session, target) {
+function copyBarDependencies(session) {
     var conf = session.conf,
-        src = path.normalize(util.format(conf.DEPENDENCIES_BAR, target)),
+        src = path.normalize(conf.DEPENDENCIES_BAR),
         dest = path.normalize(session.sourceDir);
 
     wrench.copyDirSyncRecursive(src, dest);

--- a/lib/session.js
+++ b/lib/session.js
@@ -53,7 +53,8 @@ module.exports = {
                 "ROOT": path.resolve(sourceDir),
                 "CHROME": path.normalize(path.resolve(sourceDir) + barConf.CHROME),
                 "LIB": path.normalize(path.resolve(sourceDir) + barConf.LIB),
-                "EXT": path.normalize(path.resolve(sourceDir) + barConf.EXT)
+                "EXT": path.normalize(path.resolve(sourceDir) + barConf.EXT),
+                "PLUGINS": path.normalize(path.resolve(sourceDir) + barConf.PLUGINS)
             },
             "outputDir": path.resolve(outputDir),
             "archivePath": archivePath,

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,24 @@
                             </artifactItems>
                         </configuration>
                   </execution>
+                  <execution>
+                        <id>unpack-bar-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>        
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>net.rim.BBXwebworks</groupId>
+                                    <artifactId>bar-dependencies</artifactId>
+                                    <version>1.0.0.0</version>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                  </execution>
                 </executions>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
                                 <artifactItem>
                                     <groupId>net.rim.BBXwebworks</groupId>
                                     <artifactId>packager-bin</artifactId>
-                                    <version>1.0.0.9</version>
+                                    <version>1.0.0.11</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
                                 </artifactItem>
@@ -193,7 +193,7 @@
                                 <artifactItem>
                                     <groupId>net.rim.BBXwebworks</groupId>
                                     <artifactId>bar-dependencies</artifactId>
-                                    <version>1.0.0.1</version>
+                                    <version>1.0.0.2</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
                                 </artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
                                 <artifactItem>
                                     <groupId>net.rim.BBXwebworks</groupId>
                                     <artifactId>packager-bin</artifactId>
-                                    <version>1.0.0.8</version>
+                                    <version>1.0.0.9</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
                                 </artifactItem>
@@ -193,7 +193,7 @@
                                 <artifactItem>
                                     <groupId>net.rim.BBXwebworks</groupId>
                                     <artifactId>bar-dependencies</artifactId>
-                                    <version>1.0.0.0</version>
+                                    <version>1.0.0.1</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
                                 </artifactItem>

--- a/test/unit/lib/bar-builder.js
+++ b/test/unit/lib/bar-builder.js
@@ -16,7 +16,6 @@ describe("BAR builder", function () {
 
         spyOn(wrench, "mkdirSyncRecursive");
         spyOn(fileMgr, "copyWWE");
-        spyOn(fileMgr, "copyBarDependencies");
         spyOn(nativePkgr, "exec").andCallFake(function (session, target, config, callback) {
             callback(0);
         });
@@ -25,7 +24,6 @@ describe("BAR builder", function () {
 
         expect(wrench.mkdirSyncRecursive).toHaveBeenCalledWith(session.outputDir + "/" + target);
         expect(fileMgr.copyWWE).toHaveBeenCalledWith(session, target);
-        expect(fileMgr.copyBarDependencies).toHaveBeenCalledWith(session);
         expect(nativePkgr.exec).toHaveBeenCalledWith(session, target, config, jasmine.any(Function));
         expect(callback).toHaveBeenCalledWith(0);
     });

--- a/test/unit/lib/bar-builder.js
+++ b/test/unit/lib/bar-builder.js
@@ -16,6 +16,7 @@ describe("BAR builder", function () {
 
         spyOn(wrench, "mkdirSyncRecursive");
         spyOn(fileMgr, "copyWWE");
+        spyOn(fileMgr, "copyBarDependencies");
         spyOn(nativePkgr, "exec").andCallFake(function (session, target, config, callback) {
             callback(0);
         });
@@ -24,6 +25,7 @@ describe("BAR builder", function () {
 
         expect(wrench.mkdirSyncRecursive).toHaveBeenCalledWith(session.outputDir + "/" + target);
         expect(fileMgr.copyWWE).toHaveBeenCalledWith(session, target);
+        expect(fileMgr.copyBarDependencies).toHaveBeenCalledWith(session, target);
         expect(nativePkgr.exec).toHaveBeenCalledWith(session, target, config, jasmine.any(Function));
         expect(callback).toHaveBeenCalledWith(0);
     });

--- a/test/unit/lib/bar-builder.js
+++ b/test/unit/lib/bar-builder.js
@@ -25,7 +25,7 @@ describe("BAR builder", function () {
 
         expect(wrench.mkdirSyncRecursive).toHaveBeenCalledWith(session.outputDir + "/" + target);
         expect(fileMgr.copyWWE).toHaveBeenCalledWith(session, target);
-        expect(fileMgr.copyBarDependencies).toHaveBeenCalledWith(session, target);
+        expect(fileMgr.copyBarDependencies).toHaveBeenCalledWith(session);
         expect(nativePkgr.exec).toHaveBeenCalledWith(session, target, config, jasmine.any(Function));
         expect(callback).toHaveBeenCalledWith(0);
     });

--- a/test/unit/lib/file-manager.js
+++ b/test/unit/lib/file-manager.js
@@ -11,6 +11,8 @@ var srcPath = __dirname + "/../../../lib/",
 
 describe("File manager", function () {
     it("prepareOutputFiles() should copy files and unzip archive", function () {
+        spyOn(fileMgr, "copyBarDependencies");
+
         fileMgr.prepareOutputFiles(session);
 
         expect(path.existsSync(session.sourcePaths.CHROME)).toBeTruthy();

--- a/test/unit/lib/file-manager.js
+++ b/test/unit/lib/file-manager.js
@@ -25,14 +25,6 @@ describe("File manager", function () {
         expect(fs.copySync).toHaveBeenCalledWith(path.normalize(util.format(session.conf.DEPENDENCIES_WWE, "simulator") + "/wwe"), path.normalize(session.sourceDir + "/wwe"));
     });
 
-    it("copyBarDependencies() should copy bar-dependencies dir contents to the specified target", function () {
-        spyOn(wrench, "copyDirSyncRecursive");
-
-        fileMgr.copyBarDependencies(session);
-
-        expect(wrench.copyDirSyncRecursive).toHaveBeenCalledWith(path.normalize(session.conf.DEPENDENCIES_BAR), path.normalize(session.sourceDir));
-    });
-
     it("copyExtensions() should copy files required by features listed in config.xml", function () {
         var session = testData.session,
             feature = "blackberry.app",

--- a/test/unit/lib/file-manager.js
+++ b/test/unit/lib/file-manager.js
@@ -11,8 +11,6 @@ var srcPath = __dirname + "/../../../lib/",
 
 describe("File manager", function () {
     it("prepareOutputFiles() should copy files and unzip archive", function () {
-        spyOn(fileMgr, "copyBarDependencies");
-
         fileMgr.prepareOutputFiles(session);
 
         expect(path.existsSync(session.sourcePaths.CHROME)).toBeTruthy();

--- a/test/unit/lib/file-manager.js
+++ b/test/unit/lib/file-manager.js
@@ -25,6 +25,14 @@ describe("File manager", function () {
         expect(fs.copySync).toHaveBeenCalledWith(path.normalize(util.format(session.conf.DEPENDENCIES_WWE, "simulator") + "/wwe"), path.normalize(session.sourceDir + "/wwe"));
     });
 
+    it("copyBarDependencies() should copy bar-dependencies dir contents to the specified target", function () {
+        spyOn(wrench, "copyDirSyncRecursive");
+
+        fileMgr.copyBarDependencies(session, "simulator");
+
+        expect(wrench.copyDirSyncRecursive).toHaveBeenCalledWith(path.normalize(util.format(session.conf.DEPENDENCIES_BAR, "simulator")), path.normalize(session.sourceDir));
+    });
+
     it("copyExtensions() should copy files required by features listed in config.xml", function () {
         var session = testData.session,
             feature = "blackberry.app",

--- a/test/unit/lib/file-manager.js
+++ b/test/unit/lib/file-manager.js
@@ -28,9 +28,9 @@ describe("File manager", function () {
     it("copyBarDependencies() should copy bar-dependencies dir contents to the specified target", function () {
         spyOn(wrench, "copyDirSyncRecursive");
 
-        fileMgr.copyBarDependencies(session, "simulator");
+        fileMgr.copyBarDependencies(session);
 
-        expect(wrench.copyDirSyncRecursive).toHaveBeenCalledWith(path.normalize(util.format(session.conf.DEPENDENCIES_BAR, "simulator")), path.normalize(session.sourceDir));
+        expect(wrench.copyDirSyncRecursive).toHaveBeenCalledWith(path.normalize(session.conf.DEPENDENCIES_BAR), path.normalize(session.sourceDir));
     });
 
     it("copyExtensions() should copy files required by features listed in config.xml", function () {

--- a/test/unit/lib/test-data.js
+++ b/test/unit/lib/test-data.js
@@ -15,7 +15,8 @@ module.exports = {
             "ROOT": path.resolve(outputDir + "/src"),
             "CHROME": path.normalize(path.resolve(outputDir + "/src") + barConf.CHROME),
             "LIB": path.normalize(path.resolve(outputDir + "/src") + barConf.LIB),
-            "EXT": path.normalize(path.resolve(outputDir + "/src") + barConf.EXT)
+            "EXT": path.normalize(path.resolve(outputDir + "/src") + barConf.EXT),
+            "PLUGINS": path.normalize(path.resolve(outputDir + "/src") + barConf.PLUGINS)
         },
         "archivePath": path.resolve("test/test.zip"),
         "conf": require(path.resolve(libPath + "/conf")),


### PR DESCRIPTION
Dependencies added to compiled widget should include:

_pps.so_
_jnext.so_
_auth.txt_

Dependency bin files are added via maven into our packager during build time. These files should sit in the dependencies/bar-dependencies directory of the Packager.

[http://mac-ci:9000/job/BB10-Webworks-Packager-next-bar-dependencies/](http://mac-ci:9000/job/BB10-Webworks-Packager-next-bar-dependencies/)
