### PR TITLE
Pull Req - Fixes Issues #86 and #88

### DIFF
--- a/lib/bbwp.js
+++ b/lib/bbwp.js
@@ -29,9 +29,6 @@ var path = require("path"),
 try {
     cmdline.parse(process.argv);
     session = require("./session").initialize(cmdline);
-
-    //validate session Object
-    packagerValidator.validateSession(session);
     
     //prepare files for webworks archiving
     logger.info(localize.translate("PROGRESS_FILE_POPULATING_SOURCE"));
@@ -40,6 +37,9 @@ try {
     //parse config.xml
     logger.info(localize.translate("PROGRESS_SESSION_CONFIGXML"));
     configParser.parse(path.join(session.sourceDir, "config.xml"), session, function (configObj) {
+        //validate session Object
+        packagerValidator.validateSession(session, configObj);
+        
         // copy extensions
         fileManager.copyExtensions(configObj.accessList, session.conf.EXT, session.sourcePaths.EXT);
         

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -25,6 +25,18 @@ var Localize = require("localize"),
         "EXCEPTION_MISSING_SIGNING_KEYS": {
             "en": "Cannot sign application - failed to find signing keys"
         },
+        "WARNING_MISSING_SIGNING_KEYS": {
+            "en": "Build ID set in config.xml [version], but signing keys were not found"
+        },
+        "EXCEPTION_MISSING_SIGNING_PASSWORD": {
+            "en": "Cannot sign application - No signing password provided [-g]"
+        },
+        "WARNING_SIGNING_PASSWORD_EXPECTED": {
+            "en": "Build ID set in config.xml [version], but no signing password was provided [-g]. Bar will be unsigned"
+        },
+        "EXCEPTION_MISSING_SIGNING_BUILDID": {
+            "en": "Cannot sign application - No buildId provided [--buildId]"
+        },
         "EXCEPTION_DEBUG_TOKEN_NOT_FOUND": {
             "en": "Failed to find debug token"
         },
@@ -56,19 +68,19 @@ var Localize = require("localize"),
             "en": "BAR packaging complete"
         },
         "EXCEPTION_PARSING_XML": {
-            "en": "An error has occurred parsing the config.xml. Please ensure that it is syntactically correct."
+            "en": "An error has occurred parsing the config.xml. Please ensure that it is syntactically correct"
         },
         "EXCEPTION_INVALID_VERSION": {
-            "en": "Please enter a valid application version."
+            "en": "Please enter a valid application version"
         },
         "EXCEPTION_INVALID_NAME": {
-            "en": "Please enter a valid application name."
+            "en": "Please enter a valid application name"
         },
         "EXCEPTION_INVALID_AUTHOR": {
-            "en": "Please enter an author for the application."
+            "en": "Please enter an author for the application"
         },
         "EXCEPTION_INVALID_ID": {
-            "en": "Please enter a valid application id."
+            "en": "Please enter a valid application id"
         },
         "EXCEPTION_INVALID_ICON_SRC": {
             "en": "Icon src cannot be null"

--- a/lib/packager-validator.js
+++ b/lib/packager-validator.js
@@ -25,12 +25,36 @@ var check = require('validator').check,
 _self = {
     //TODO create one global validate method that will validate
     //both the session and configObj?
-    validateSession: function (session) {
-        //If -g <password> is set, but no keys were found, throw an error
-        //The string check is to get around a really weird issue in commander
-        //where when -g is not provided, the storepass comes in as a function...
-        if (session.storepass && typeof session.storepass === "string" && !session.keystore) {
-            throw localize.translate("EXCEPTION_MISSING_SIGNING_KEYS");
+    validateSession: function (session, widgetConfig) {
+        //The string checks below is to get around a really weird issue in commander
+        //where sometimes unspecified arguments come in as a function...
+        var keysFound = session.keystore,
+            keysPassword = session.storepass && typeof session.storepass === "string",
+            commandLinebuildId = session.buildId && typeof session.buildId === "string",//--buildId
+            buildId = widgetConfig.buildId && typeof widgetConfig.buildId === "string";//Finalized Build ID
+            
+        //Signing keys exist?
+        if (!keysFound) {
+            if (keysPassword || commandLinebuildId) {
+                //If -g <password> or --buildId is set, but no keys were found, throw an error
+                throw localize.translate("EXCEPTION_MISSING_SIGNING_KEYS");
+            } else if (buildId) {
+                //If a buildId exists in config, but no keys were found, throw a warning
+                logger.warn(localize.translate("WARNING_MISSING_SIGNING_KEYS"));
+            }
+        }
+        
+        //if -g was provided with NO build id, throw error
+        if (keysPassword && !buildId) {
+            throw localize.translate("EXCEPTION_MISSING_SIGNING_BUILDID");
+        }
+        
+        if (commandLinebuildId && !keysPassword) {
+            //if --buildId was provided with NO password, throw error
+            throw localize.translate("EXCEPTION_MISSING_SIGNING_PASSWORD");
+        } else if (buildId && !keysPassword) {
+            //if a buildId was provided in config.xml with NO password, throw warning
+            logger.warn(localize.translate("WARNING_SIGNING_PASSWORD_EXPECTED"));
         }
     }
 };

--- a/lib/session.js
+++ b/lib/session.js
@@ -23,15 +23,20 @@ var path = require("path"),
 module.exports = {
     initialize: function (cmdline) {
         var sourceDir,
+            signingPassword,
             outputDir = cmdline.output,
             archivePath = path.resolve(cmdline.args[0]),
             archiveName = path.basename(archivePath, '.zip'),
-            signingPassword = cmdline.password,
             buildId = cmdline.buildId;
 
         //If -o option was not provided, default output location is the current directory
         outputDir = outputDir || process.cwd();
 
+        //Only set signingPassword if it contains a value
+        if (cmdline.password && "string" === typeof cmdline.password) {
+            signingPassword = cmdline.password;
+        }
+        
         //If -s [dir] is provided
         if (cmdline.source && "string" === typeof cmdline.source) {
             sourceDir = cmdline.source + "/src";

--- a/test/unit/lib/packager-validator.js
+++ b/test/unit/lib/packager-validator.js
@@ -2,17 +2,95 @@ var srcPath = __dirname + "/../../../lib/",
     testData = require("./test-data"),
     testUtilities = require("./test-utilities"),
     localize = require(srcPath + "localize"),
+    logger = require(srcPath + "logger"),
     packagerValidator = require(srcPath + "packager-validator"),
     cmd;
 
 describe("Packager Validator", function () {
-    it("throws an exception when trying to sign and keys were not found", function () {
-        var session = testUtilities.cloneObj(testData.session);
-        session.storepass = "myPassword";
+    it("throws an exception when -g set and keys were not found", function () {
+        var session = testUtilities.cloneObj(testData.session),
+            configObj = testUtilities.cloneObj(testData.config);
+        
+        //setup signing parameters
         session.keystore = undefined;
+        session.storepass = "myPassword";
         
         expect(function () {
-            packagerValidator.validateSession(session);
+            packagerValidator.validateSession(session, configObj);
         }).toThrow(localize.translate("EXCEPTION_MISSING_SIGNING_KEYS"));
+    });
+    
+    it("throws an exception when --buildId set and keys were not found", function () {
+        var session = testUtilities.cloneObj(testData.session),
+            configObj = testUtilities.cloneObj(testData.config);
+        
+        //setup signing parameters
+        session.keystore = undefined;
+        session.buildId = "100";
+        
+        expect(function () {
+            packagerValidator.validateSession(session, configObj);
+        }).toThrow(localize.translate("EXCEPTION_MISSING_SIGNING_KEYS"));
+    });
+    
+    it("generated a warning when Build ID is set in config and keys were not found", function () {
+        var session = testUtilities.cloneObj(testData.session),
+            configObj = testUtilities.cloneObj(testData.config);
+        
+        //Mock the logger
+        spyOn(logger, "warn");
+        
+        //setup signing parameters
+        session.keystore = undefined;
+        session.buildId = undefined;
+        configObj.buildId = "100";
+        
+        packagerValidator.validateSession(session, configObj);
+        expect(logger.warn).toHaveBeenCalledWith(localize.translate("WARNING_MISSING_SIGNING_KEYS"));
+    });
+    
+    it("throws an exception when a password [-g] was set with no buildId", function () {
+        var session = testUtilities.cloneObj(testData.session),
+            configObj = testUtilities.cloneObj(testData.config);
+        
+        //setup signing parameters
+        session.keystore = "c:/author.p12";
+        session.storepass = "myPassword";
+        configObj.buildId = undefined;
+        
+        expect(function () {
+            packagerValidator.validateSession(session, configObj);
+        }).toThrow(localize.translate("EXCEPTION_MISSING_SIGNING_BUILDID"));
+    });
+    
+    it("throws an exception when --buildId was set with no password [-g]", function () {
+        var session = testUtilities.cloneObj(testData.session),
+            configObj = testUtilities.cloneObj(testData.config);
+        
+        //setup signing parameters
+        session.keystore = "c:/author.p12";
+        session.storepass = undefined;
+        session.buildId = "100";
+        
+        expect(function () {
+            packagerValidator.validateSession(session, configObj);
+        }).toThrow(localize.translate("EXCEPTION_MISSING_SIGNING_PASSWORD"));
+    });
+    
+    it("generates a warning when the config contains a build id and no password was provided[-g]", function () {
+        var session = testUtilities.cloneObj(testData.session),
+            configObj = testUtilities.cloneObj(testData.config);
+        
+        //setup signing parameters
+        session.keystore = "c:/author.p12";
+        session.storepass = undefined;
+        session.buildId = undefined;
+        configObj.buildId = "100";
+        
+        //Mock the logger
+        spyOn(logger, "warn");
+        
+        packagerValidator.validateSession(session, configObj);
+        expect(logger.warn).toHaveBeenCalledWith(localize.translate("WARNING_SIGNING_PASSWORD_EXPECTED"));
     });
 });

--- a/test/unit/lib/session.js
+++ b/test/unit/lib/session.js
@@ -65,8 +65,19 @@ describe("Session", function () {
             password: 'myPassword'
         },
         result = session.initialize(data);
-        
         expect(result.storepass).toEqual('myPassword');
+    });
+    
+    it("does not set the password when not a string", function () {
+        //Commander somtimes improperly sets password to a function, when no value provided
+        var data = {
+            args: [ 'C:/sampleApp/sample.zip' ],
+            output: 'C:/sampleApp/bin',
+            source: 'C:/sampleApp/mySource',//equivalent to [-s C:/sampleApp/mySource]
+            password: function () {}
+        },
+        result = session.initialize(data);
+        expect(result.storepass).toBeUndefined();
     });
     
     it("sets the buildId when specified [-buildId]", function () {
@@ -77,7 +88,6 @@ describe("Session", function () {
             buildId: '100'
         },
         result = session.initialize(data);
-        
         expect(result.buildId).toEqual('100');
     });
     


### PR DESCRIPTION
Fixes issue #86 - Packager automatically attempts to sign without -g
Fixes issue #88 - No error if signing with -g but no -b, and version="x.x.x" and vice versa (no -g with a -buildId)

Lots of error/warning handling added for issue #88 fix +unit tests
