### PR TITLE
Pull req - Fixes issue #56 [Native Packager exception occurs when there is an empty <rim:permit> element, however bar file is still created]

### DIFF
--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -219,6 +219,11 @@ function processPermissionsData(data, widgetConfig) {
     if (widgetConfig.permissions.indexOf("access_internet") === -1) {
         widgetConfig.permissions.push("access_internet");
     }
+    
+    //Remove any empty permission elements
+    widgetConfig.permissions = widgetConfig.permissions.filter(function (val) {
+        return typeof val === "string";
+    });
 }
 
 function validateConfig(widgetConfig) {

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -199,6 +199,17 @@ describe("xml parser", function () {
             expect(customAccessList.features).toEqual([]);
         });
     });
+        
+    it("does not throw an exception with empty permit tags", function () {
+        var data = testUtilities.cloneObj(testData.xml2jsConfig);
+        data['rim:permit'] = ['read_geolocation', {}, 'access_internet' ];
+        
+        mockParsing(data);
+        
+        expect(function () {
+            configParser.parse(configPath, session, function (configObj) {});
+        }).not.toThrow();
+    });
 
     it("multi access should be false if no access", function () {
         var data = testUtilities.cloneObj(testData.xml2jsConfig);


### PR DESCRIPTION
Fixes issue #56 - Native Packager exception occurs when there is an empty rim:permit element, however bar file is still created
- unit tests
