### PR TITLE
Pull req - Fixed issue #93 [command line parameter - double dash used in buildid now instead single dash ( --buildId vs. -buildId)]

### DIFF
--- a/lib/cmdline.js
+++ b/lib/cmdline.js
@@ -22,6 +22,7 @@ cmd
     .usage('[drive:][path]archive [-s [dir]] [[ -g genpassword] [-buildId num]] [-o dir] [-d]')
     .option('-s, --source [dir]', 'Save source. The default behaviour is to not save the source files. If dir is specified then creates dir\\src\\ directory structure. If no dir specified then the path of archive is assumed')
     .option('-g, --password <password>', 'Signing key password')
+    .option('-buildId <num>', '[deprecated] Use --buildId.')
     .option('-b, --buildId <num>', 'Specifies the build number for signing (typically incremented from previous signing).')
     .option('-o, --output <dir>', 'Redirects output file location to dir. If both -o and dir are not specified then the path of archive is assumed')
     .option('-d, --debug', 'Allows use of not signed build on device by utilizing debug token and enables Web Inspector.')
@@ -31,6 +32,13 @@ if (!process.argv[2]) {
     //no args passed into [node bbwp.js], show the help information
     logger.info(cmd.helpInformation());
     process.exit();
+}
+
+//Handle deprecated option -buildId
+for (var i = 0; i < process.argv.length; i++) {
+    if (process.argv[i] === "-buildId") {
+        process.argv[i] = "--buildId";
+    }
 }
     
 module.exports = cmd;

--- a/test/unit/lib/cmdline.js
+++ b/test/unit/lib/cmdline.js
@@ -48,4 +48,9 @@ describe("Command line", function () {
         cmd.parseOptions(["--buildId", "100"]);
         expect(cmd.buildId).toEqual("100");
     });
+    
+    it("accepts -buildId with argument", function () {
+        cmd.parseOptions(["-buildId", "100"]);
+        expect(cmd.buildId).toEqual("100");
+    });
 });


### PR DESCRIPTION
Fixed issue #93 - command line parameter - double dash used in buildid now instead single dash ( --buildId vs. -buildId)
- unit test
