### PR TITLE
Pull Req: Remove BBX-Emulator and exclude node_modules in maven artifact

### DIFF
--- a/build/build/conf.js
+++ b/build/build/conf.js
@@ -24,6 +24,5 @@ module.exports = {
     DEPENDENCIES: path.normalize(__dirname + "/../../dependencies"),
     NODE_MOD: path.normalize(__dirname + "/../../node_modules"),
     FRAMEWORK: path.normalize(__dirname + "/../../Framework"),
-    FRAMEWORK_DEPLOY: path.normalize(__dirname + "/../../Framework/target/zip/*"),
-    FRAMEWORK_EMU_LIB: path.normalize(__dirname + "/../../Framework/dependencies/BBX-Emulator/lib/*")
+    FRAMEWORK_DEPLOY: path.normalize(__dirname + "/../../Framework/target/zip/*")
 };

--- a/build/build/pack.js
+++ b/build/build/pack.js
@@ -44,7 +44,6 @@ function _copyCmd(source, destination) {
 function _copyFiles() {
     var cmdSep = " && ";
     return  _copyCmd(_c.FRAMEWORK_DEPLOY, 'Framework/') + cmdSep +
-            _copyCmd(_c.FRAMEWORK_EMU_LIB, 'dependencies/BBX-Emulator/') + cmdSep +
             _copyCmd(_c.LIB, 'lib') + cmdSep +
             _copyCmd(_c.NODE_MOD, 'node_modules') + cmdSep +
             _copyCmd(_c.ROOT + 'bbwp', '') + cmdSep +


### PR DESCRIPTION
- Updates Framework submodule to include the changes seen in blackberry-webworks/BB10-WebWorks-Framework#11 
- Removes blackberry-webworks/BBX-Emulator references
