### PR TITLE
Fixed issue #81 [When typing "bbwp", packager prints out "Usage: undefined..." instead of "Usage: bbwp..."]

### DIFF
--- a/lib/cmdline.js
+++ b/lib/cmdline.js
@@ -30,8 +30,7 @@ cmd
 
 if (!process.argv[2]) {
     //no args passed into [node bbwp.js], show the help information
-    logger.info(cmd.helpInformation());
-    process.exit();
+    process.argv.push("-h");
 }
 
 //Handle deprecated option -buildId


### PR DESCRIPTION
_see title_
