### PR TITLE
Pull req - Fixes issue #55 [Improper error message is shown when the `<author>` element is empty]

### DIFF
--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -129,7 +129,8 @@ function processAuthorData(data, widgetConfig) {
     if (data.author) {
         var attribs = data.author["@"];
 
-        if (!attribs) {
+        if (!attribs && typeof data.author === "string") {
+            //do not sanitize empty objects {} (must be string)
             widgetConfig.author = sanitize(data.author).trim();
         } else if (data.author["#"]) {
             widgetConfig.author = sanitize(data.author["#"]).trim();

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -366,4 +366,16 @@ describe("xml parser", function () {
             expect(configObj.buildId).toEqual("100");
         });
     });
+    
+    it("throws a proper error when author tag is empty", function () {
+        var data = testUtilities.cloneObj(testData.xml2jsConfig);
+        data.author = {};
+        
+        mockParsing(data);
+        
+        //Should throw an EXCEPTION_INVALID_AUTHOR error
+        expect(function () {
+            configParser.parse(configPath, session, {});
+        }).toThrow(localize.translate("EXCEPTION_INVALID_AUTHOR"));
+    });
 });


### PR DESCRIPTION
Fixes issue #55 [Improper error message is shown when the `<author>` element is empty]
+unit tests
