### PR TITLE
Pull req - Refactored code that copies .so files for extensions into the bar

### DIFF
--- a/lib/bar-builder.js
+++ b/lib/bar-builder.js
@@ -35,6 +35,9 @@ function buildTarget(previous, baton) {
     fileManager.copyBarDependencies(this.session, target);
     fileManager.copyExtensions(this.config.accessList, this.session, target);
     
+    //Generate frameworkModules.js (this needs to be done AFTER all files have been copied)
+    fileManager.generateFrameworkModulesJS(this.session);
+    
     //Call native-packager module for target
     nativePkgr.exec(this.session, target, this.config, function (code) {
         if (code !== 0) {

--- a/lib/bar-builder.js
+++ b/lib/bar-builder.js
@@ -26,9 +26,16 @@ function buildTarget(previous, baton) {
     baton.take();
 
     var target = this.session.targets[targetIdx++];
+    
+    //Create output folder
     wrench.mkdirSyncRecursive(this.session.outputDir + "/" + target);
+    
+    //Copy target dependent files
     fileManager.copyWWE(this.session, target);
     fileManager.copyBarDependencies(this.session, target);
+    fileManager.copyExtensions(this.config.accessList, this.session, target);
+    
+    //Call native-packager module for target
     nativePkgr.exec(this.session, target, this.config, function (code) {
         if (code !== 0) {
             logger.error(localize.translate("EXCEPTION_NATIVEPACKAGER"));

--- a/lib/bar-conf.js
+++ b/lib/bar-conf.js
@@ -21,5 +21,6 @@ self.CHROME = self.ROOT + "/chrome";
 self.LIB = self.CHROME + "/lib";
 self.EXT = self.CHROME + "/ext";
 self.PLUGINS = self.ROOT + "/plugins";
+self.PPS = self.ROOT + "/plugins/jnext";
 
 module.exports = self;

--- a/lib/bar-conf.js
+++ b/lib/bar-conf.js
@@ -21,6 +21,6 @@ self.CHROME = self.ROOT + "/chrome";
 self.LIB = self.CHROME + "/lib";
 self.EXT = self.CHROME + "/ext";
 self.PLUGINS = self.ROOT + "/plugins";
-self.PPS = self.ROOT + "/plugins/jnext";
+self.JNEXT_PLUGINS = self.ROOT + "/plugins/jnext";
 
 module.exports = self;

--- a/lib/bbwp.js
+++ b/lib/bbwp.js
@@ -40,9 +40,6 @@ try {
         //validate session Object
         packagerValidator.validateSession(session, configObj);
         
-        // copy extensions
-        fileManager.copyExtensions(configObj.accessList, session.conf.EXT, session.sourcePaths.EXT);
-        
         //generate user.js and frameworkModules.js
         logger.info(localize.translate("PROGRESS_GEN_OUTPUT"));
         //Adding debuEnabled property to user.js. Framework will enable/disable WebInspector based on that variable.

--- a/lib/bbwp.js
+++ b/lib/bbwp.js
@@ -40,13 +40,11 @@ try {
         //validate session Object
         packagerValidator.validateSession(session, configObj);
         
-        //generate user.js and frameworkModules.js
+        //generate user.js
         logger.info(localize.translate("PROGRESS_GEN_OUTPUT"));
         //Adding debuEnabled property to user.js. Framework will enable/disable WebInspector based on that variable.
         configObj.debugEnabled = session.debug;
         packagerUtils.writeFile(path.join(session.sourcePaths.LIB, "config"), "user.js", "module.exports = " + JSON.stringify(configObj) + ";");
-
-        fileManager.generateFrameworkModulesJS(session);
 
         barBuilder.build(session, configObj, function (code) {
             fileManager.cleanSource(session);

--- a/lib/file-manager.js
+++ b/lib/file-manager.js
@@ -164,7 +164,7 @@ function copyExtensions(accessList, session, target) {
     var extPath = session.conf.EXT,
         extDest = session.sourcePaths.EXT,
         soPath,
-        soDest = session.sourcePaths.PPS,
+        soDest = session.sourcePaths.JNEXT_PLUGINS,
         apiDir, apiNativeDir, jsFiles, soFiles,
         copied = {};
 
@@ -183,7 +183,7 @@ function copyExtensions(accessList, session, target) {
                         checkAPIFolder(apiDir);
                         
                         //create output folders
-                        wrench.mkdirSyncRecursive(extDest + "/" + feature.id, "0755");
+                        wrench.mkdirSyncRecursive(path.join(extDest, feature.id), "0755");
                         wrench.mkdirSyncRecursive(soDest, "0755");
                         
                         //find all .js files

--- a/lib/file-manager.js
+++ b/lib/file-manager.js
@@ -16,6 +16,7 @@
 
 var path = require("path"),
     util = require("util"),
+    packager_utils = require("./packager-utils"),
     fs = require("fsext"),
     wrench = require("wrench"),
     zip = require("zip"),
@@ -157,25 +158,55 @@ function checkNonJSFiles(dir) {
 function checkAPIFolder(apiDir) {
     checkMissingFileInAPIFolder(apiDir, CLIENT_JS);
     checkMissingFileInAPIFolder(apiDir, SERVER_JS);
-    checkNonJSFiles(apiDir);
 }
 
-function copyExtensions(accessList, extPath, to) {
-    var apiDir,
+function copyExtensions(accessList, session, target) {
+    var extPath = session.conf.EXT,
+        extDest = session.sourcePaths.EXT,
+        soPath,
+        soDest = session.sourcePaths.PPS,
+        apiDir, apiNativeDir, jsFiles, soFiles,
         copied = {};
 
     if (path.existsSync(extPath)) {
         accessList.forEach(function (accessListEntry) {
             accessListEntry.features.forEach(function (feature) {
-                apiDir = path.resolve(extPath, feature.id);
+                apiDir = path.normalize(path.resolve(extPath, feature.id));
+                apiNativeDir = path.normalize(path.join(apiDir, "native"));
+                soPath = path.normalize(path.join(apiDir, target));
 
                 if (!copied.hasOwnProperty(feature.id)) {
                     copied[feature.id] = true;
 
                     if (path.existsSync(apiDir)) {
+                        //verify mandatory api files exist
                         checkAPIFolder(apiDir);
-                        wrench.mkdirSyncRecursive(to + "/" + feature.id, "0755");
-                        wrench.copyDirSyncRecursive(apiDir, to + "/" + feature.id);
+                        
+                        //create output folders
+                        wrench.mkdirSyncRecursive(extDest + "/" + feature.id, "0755");
+                        wrench.mkdirSyncRecursive(soDest, "0755");
+                        
+                        //find all .js files
+                        jsFiles = packager_utils.listFiles(apiDir, function (file) {
+                            return path.extname(file) === ".js";
+                        });
+                        
+                        //Copy each .js file to its extensions folder
+                        jsFiles.forEach(function (jsFile) {
+                            packager_utils.copyFile(jsFile, path.join(extDest, feature.id), apiDir);
+                        });
+                        
+                        if (path.existsSync(soPath) && path.existsSync(apiNativeDir)) {
+                            //find all .so files
+                            soFiles = packager_utils.listFiles(soPath, function (file) {
+                                return path.extname(file) === ".so";
+                            });
+                            
+                            //Copy each .so file to the extensions folder
+                            soFiles.forEach(function (soFile) {
+                                packager_utils.copyFile(soFile, soDest);
+                            });
+                        }
                     } else {
                         throw localize.translate("EXCEPTION_FEATURE_NOT_FOUND", feature.id);
                     }

--- a/lib/packager-utils.js
+++ b/lib/packager-utils.js
@@ -71,6 +71,9 @@ _self = {
             filteredFiles = [];
         
         files.forEach(function (file) {
+            //On mac wrench.readdirSyncRecursive does not return absolute paths, so resolve one.
+            file = path.resolve(directory, file);
+        
             if (filter(file)) {
                 filteredFiles.push(file);
             }

--- a/lib/packager-utils.js
+++ b/lib/packager-utils.js
@@ -49,6 +49,35 @@ _self = {
             if (err) throw err;
         });
     },
+    
+    copyFile: function (srcFile, destDir, baseDir) {
+        var filename = path.basename(srcFile),
+            fileBuffer = fs.readFileSync(srcFile),
+            fileLocation;
+        
+        //if a base directory was provided, determine
+        //folder structure from the relative path of the base folder
+        if (baseDir && srcFile.indexOf(baseDir) === 0) {
+            fileLocation = srcFile.replace(baseDir, destDir);
+            wrench.mkdirSyncRecursive(path.dirname(fileLocation), "0755");
+            fs.writeFileSync(fileLocation, fileBuffer);
+        } else {
+            fs.writeFileSync(path.join(destDir, filename), fileBuffer);
+        }
+    },
+    
+    listFiles: function (directory, filter) {
+        var files = wrench.readdirSyncRecursive(directory),
+            filteredFiles = [];
+        
+        files.forEach(function (file) {
+            if (filter(file)) {
+                filteredFiles.push(file);
+            }
+        });
+        
+        return filteredFiles;
+    },
 
     isWindows: function () {
         return os.type().toLowerCase().indexOf("windows") >= 0;

--- a/lib/session.js
+++ b/lib/session.js
@@ -57,7 +57,8 @@ module.exports = {
                 "CHROME": path.normalize(path.resolve(sourceDir) + barConf.CHROME),
                 "LIB": path.normalize(path.resolve(sourceDir) + barConf.LIB),
                 "EXT": path.normalize(path.resolve(sourceDir) + barConf.EXT),
-                "PLUGINS": path.normalize(path.resolve(sourceDir) + barConf.PLUGINS)
+                "PLUGINS": path.normalize(path.resolve(sourceDir) + barConf.PLUGINS),
+                "PPS": path.normalize(path.resolve(sourceDir) + barConf.PPS)
             },
             "outputDir": path.resolve(outputDir),
             "archivePath": archivePath,

--- a/lib/session.js
+++ b/lib/session.js
@@ -58,7 +58,7 @@ module.exports = {
                 "LIB": path.normalize(path.resolve(sourceDir) + barConf.LIB),
                 "EXT": path.normalize(path.resolve(sourceDir) + barConf.EXT),
                 "PLUGINS": path.normalize(path.resolve(sourceDir) + barConf.PLUGINS),
-                "PPS": path.normalize(path.resolve(sourceDir) + barConf.PPS)
+                "JNEXT_PLUGINS": path.normalize(path.resolve(sourceDir) + barConf.JNEXT_PLUGINS)
             },
             "outputDir": path.resolve(outputDir),
             "archivePath": archivePath,

--- a/test/unit/lib/bar-builder.js
+++ b/test/unit/lib/bar-builder.js
@@ -18,6 +18,7 @@ describe("BAR builder", function () {
         spyOn(fileMgr, "copyWWE");
         spyOn(fileMgr, "copyBarDependencies");
         spyOn(fileMgr, "copyExtensions");
+        spyOn(fileMgr, "generateFrameworkModulesJS");
         spyOn(nativePkgr, "exec").andCallFake(function (session, target, config, callback) {
             callback(0);
         });
@@ -28,6 +29,7 @@ describe("BAR builder", function () {
         expect(fileMgr.copyWWE).toHaveBeenCalledWith(session, target);
         expect(fileMgr.copyBarDependencies).toHaveBeenCalledWith(session, target);
         expect(fileMgr.copyExtensions).toHaveBeenCalledWith(config.accessList, session, target);
+        expect(fileMgr.generateFrameworkModulesJS).toHaveBeenCalledWith(session);
         expect(nativePkgr.exec).toHaveBeenCalledWith(session, target, config, jasmine.any(Function));
         expect(callback).toHaveBeenCalledWith(0);
     });

--- a/test/unit/lib/bar-builder.js
+++ b/test/unit/lib/bar-builder.js
@@ -17,6 +17,7 @@ describe("BAR builder", function () {
         spyOn(wrench, "mkdirSyncRecursive");
         spyOn(fileMgr, "copyWWE");
         spyOn(fileMgr, "copyBarDependencies");
+        spyOn(fileMgr, "copyExtensions");
         spyOn(nativePkgr, "exec").andCallFake(function (session, target, config, callback) {
             callback(0);
         });
@@ -26,6 +27,7 @@ describe("BAR builder", function () {
         expect(wrench.mkdirSyncRecursive).toHaveBeenCalledWith(session.outputDir + "/" + target);
         expect(fileMgr.copyWWE).toHaveBeenCalledWith(session, target);
         expect(fileMgr.copyBarDependencies).toHaveBeenCalledWith(session, target);
+        expect(fileMgr.copyExtensions).toHaveBeenCalledWith(config.accessList, session, target);
         expect(nativePkgr.exec).toHaveBeenCalledWith(session, target, config, jasmine.any(Function));
         expect(callback).toHaveBeenCalledWith(0);
     });

--- a/test/unit/lib/test-data.js
+++ b/test/unit/lib/test-data.js
@@ -17,7 +17,7 @@ module.exports = {
             "LIB": path.normalize(path.resolve(outputDir + "/src") + barConf.LIB),
             "EXT": path.normalize(path.resolve(outputDir + "/src") + barConf.EXT),
             "PLUGINS": path.normalize(path.resolve(outputDir + "/src") + barConf.PLUGINS),
-            "PPS": path.normalize(path.resolve(outputDir + "/src") + barConf.PPS)
+            "JNEXT_PLUGINS": path.normalize(path.resolve(outputDir + "/src") + barConf.JNEXT_PLUGINS)
         },
         "archivePath": path.resolve("test/test.zip"),
         "conf": require(path.resolve(libPath + "/conf")),

--- a/test/unit/lib/test-data.js
+++ b/test/unit/lib/test-data.js
@@ -16,7 +16,8 @@ module.exports = {
             "CHROME": path.normalize(path.resolve(outputDir + "/src") + barConf.CHROME),
             "LIB": path.normalize(path.resolve(outputDir + "/src") + barConf.LIB),
             "EXT": path.normalize(path.resolve(outputDir + "/src") + barConf.EXT),
-            "PLUGINS": path.normalize(path.resolve(outputDir + "/src") + barConf.PLUGINS)
+            "PLUGINS": path.normalize(path.resolve(outputDir + "/src") + barConf.PLUGINS),
+            "PPS": path.normalize(path.resolve(outputDir + "/src") + barConf.PPS)
         },
         "archivePath": path.resolve("test/test.zip"),
         "conf": require(path.resolve(libPath + "/conf")),


### PR DESCRIPTION
 Refactored code that copies extensions to match requirements for US18240 (see below) + updated unit tests + 2 new utility functions
1. All JavaScript files from the extensions are included in the final bar and directory structure is maintained and ext is transfered to chrome/ext
2. native folder is ignored.
3. device folder under extension contains a .so file, this .so file needs to be placed under plugins/jnext
4. simulator under extension contains a .so file, this .so file needs to be placed under plugins/jnext
5. basically the simulator and device .so files need to make it into the same folder as pps.so
6. device and simulator folders might not exist. Existence of the native, device, simulator can be used as validation whether this extension has native code. Native code is optional for extensions.
