### PR TITLE
Pull Req: Allow spaces for widget id

### DIFF
--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -233,7 +233,7 @@ function validateConfig(widgetConfig) {
         .regex("^[0-9]{1,3}([.][0-9]{1,3}){2,3}$");
     check(widgetConfig.name, localize.translate("EXCEPTION_INVALID_NAME")).notEmpty();
     check(widgetConfig.author, localize.translate("EXCEPTION_INVALID_AUTHOR")).notNull();
-    check(widgetConfig.id, localize.translate("EXCEPTION_INVALID_ID")).regex("^[a-zA-Z][a-zA-Z0-9]*$");
+    check(widgetConfig.id, localize.translate("EXCEPTION_INVALID_ID")).regex("^[a-zA-Z][a-zA-Z0-9 ]*[a-zA-Z0-9]$");
 
     if (widgetConfig.icon) {
         check(widgetConfig.icon, localize.translate("EXCEPTION_INVALID_ICON_SRC")).notNull();

--- a/test/config.xml
+++ b/test/config.xml
@@ -2,7 +2,7 @@
 <widget xmlns=" http://www.w3.org/ns/widgets"
         xmlns:rim="http://www.blackberry.com/ns/widgets"
         version="1.0.0"
-        id="MyWidgetId">
+        id="My WidgetId">
     <name>Demo</name>
     <content src="local:///startPage.html"/>
     <author rim:copyright="No Copyright"

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -22,7 +22,7 @@ describe("xml parser", function () {
     it("parses standard elements in a config.xml", function () {
         configParser.parse(configPath, session, function (configObj) {
             expect(configObj.content).toEqual("local:///startPage.html");
-            expect(configObj.id).toEqual("MyWidgetId");
+            expect(configObj.id).toEqual("My WidgetId");
             expect(configObj.version).toEqual("1.0.0");
             expect(configObj.license).toEqual("My License");
             expect(configObj.licenseURL).toEqual("http://www.apache.org/licenses/LICENSE-2.0");
@@ -139,6 +139,30 @@ describe("xml parser", function () {
     it("fails when id contains a non [a-zA-Z0-9] character", function () {
         var data = testUtilities.cloneObj(testData.xml2jsConfig);
         data["@"].id = "abcde#fghijk";
+        
+        mockParsing(data);
+        
+        //Should throw an EXCEPTION_INVALID_ID error
+        expect(function () {
+            configParser.parse(configPath, session, {});
+        }).toThrow(localize.translate("EXCEPTION_INVALID_ID"));
+    });
+
+    it("fails when id starts with a space", function () {
+        var data = testUtilities.cloneObj(testData.xml2jsConfig);
+        data["@"].id = " abcdefghijk";
+        
+        mockParsing(data);
+        
+        //Should throw an EXCEPTION_INVALID_ID error
+        expect(function () {
+            configParser.parse(configPath, session, {});
+        }).toThrow(localize.translate("EXCEPTION_INVALID_ID"));
+    });
+
+    it("fails when id ends with a space", function () {
+        var data = testUtilities.cloneObj(testData.xml2jsConfig);
+        data["@"].id = "abcdefghijk ";
         
         mockParsing(data);
         


### PR DESCRIPTION
Allows spaces within widget id string except first and last characters positions.

Fixes blackberry/BB10-Webworks-Packager#91
