### PR TITLE
Pull Req: Always whitelist blackberry.event

### DIFF
--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -24,6 +24,11 @@ var fs = require('fs'),
     logger = require("./logger"),
     fileManager = require("./file-manager"),
     utils = require("./packager-utils"),
+    _FREE_FEATURES = [{
+        version: "1.0.0.0",
+        required: true,
+        id: "blackberry.event"
+    }], // the list of features that come for free, user does not need to whitelist manually
     _self;
 
 function createAccessListObj(featuresArray, uri, allowSubDomain) {
@@ -43,6 +48,17 @@ function createAccessListObj(featuresArray, uri, allowSubDomain) {
             accessObj.features.push(attribs);
         });
     }
+
+    // always add free features to whitelist
+    _FREE_FEATURES.forEach(function (feature) {
+        var featureFound = accessObj.features.reduce(function (found, currElem) {
+                return found || currElem.id === feature.id;
+            }, false);
+
+        if (!featureFound) {
+            accessObj.features.push(feature);
+        }
+    });
 
     return accessObj;
 }
@@ -282,6 +298,9 @@ _self = {
                 callback(processResult(result, session));
             }
         });
+    },
+    getFreeFeatures: function () {
+        return _FREE_FEATURES;
     }
 };
 

--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -24,6 +24,11 @@ var fs = require('fs'),
     logger = require("./logger"),
     fileManager = require("./file-manager"),
     utils = require("./packager-utils"),
+    GLOBAL_FEATURES = [{
+        version: "1.0.0.0",
+        required: true,
+        id: "blackberry.event"
+    }], // the list of features that come for free, user does not need to whitelist manually    
     _self;
 
 function createAccessListObj(featuresArray, uri, allowSubDomain) {
@@ -44,8 +49,8 @@ function createAccessListObj(featuresArray, uri, allowSubDomain) {
         });
     }
 
-    // always add free features to whitelist
-    fileManager.getFreeFeatures().forEach(function (feature) {
+    // always add global features to whitelist
+    GLOBAL_FEATURES.forEach(function (feature) {
         var featureFound = accessObj.features.reduce(function (found, currElem) {
                 return found || currElem.id === feature.id;
             }, false);
@@ -293,6 +298,9 @@ _self = {
                 callback(processResult(result, session));
             }
         });
+    },
+    getGlobalFeatures: function () {
+        return GLOBAL_FEATURES;
     }
 };
 

--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -24,11 +24,6 @@ var fs = require('fs'),
     logger = require("./logger"),
     fileManager = require("./file-manager"),
     utils = require("./packager-utils"),
-    _FREE_FEATURES = [{
-        version: "1.0.0.0",
-        required: true,
-        id: "blackberry.event"
-    }], // the list of features that come for free, user does not need to whitelist manually
     _self;
 
 function createAccessListObj(featuresArray, uri, allowSubDomain) {
@@ -50,7 +45,7 @@ function createAccessListObj(featuresArray, uri, allowSubDomain) {
     }
 
     // always add free features to whitelist
-    _FREE_FEATURES.forEach(function (feature) {
+    fileManager.getFreeFeatures().forEach(function (feature) {
         var featureFound = accessObj.features.reduce(function (found, currElem) {
                 return found || currElem.id === feature.id;
             }, false);
@@ -298,9 +293,6 @@ _self = {
                 callback(processResult(result, session));
             }
         });
-    },
-    getFreeFeatures: function () {
-        return _FREE_FEATURES;
     }
 };
 

--- a/lib/file-manager.js
+++ b/lib/file-manager.js
@@ -22,12 +22,7 @@ var path = require("path"),
     zip = require("zip"),
     localize = require("./localize"),
     CLIENT_JS = "client.js",
-    SERVER_JS = "index.js",
-    FREE_FEATURES = [{
-        version: "1.0.0.0",
-        required: true,
-        id: "blackberry.event"
-    }]; // the list of features that come for free, user does not need to whitelist manually
+    SERVER_JS = "index.js";
 
 function unzip(from, to) {
     var data, entries, p, parent;
@@ -100,38 +95,19 @@ function getModulesArray(dest, files, baseDir) {
     return modulesList;
 }
 
-function isFreeModule(path) {
-    var extId = /(\w+)\/([a-z.]+)\/([a-z.]+)/.exec(path)[2];
-    return FREE_FEATURES.reduce(
-        function (free, currFeature) {
-            return free || currFeature.id === extId;
-        },
-        false);
-}
-
 function generateFrameworkModulesJS(session) {
     var dest = session.sourcePaths,
         modulesList = [],
         modulesStr = "var frameworkModules = ",
         libFiles = wrench.readdirSyncRecursive(dest.LIB),
         extFiles,
-        extModules,
-        freeModules;
+        extModules;
 
     modulesList = modulesList.concat(getModulesArray(dest, libFiles, dest.LIB));
 
     if (path.existsSync(dest.EXT)) {
         extFiles = wrench.readdirSyncRecursive(dest.EXT);
         extModules = getModulesArray(dest, extFiles, dest.EXT);
-        freeModules = extModules.filter(isFreeModule);
-        extModules = extModules.filter(function (path) {
-            return freeModules.indexOf(path) < 0;
-        });
-
-        // load extensions that need to be always available first
-        modulesList = modulesList.concat(freeModules);
-
-        // load other extensions
         modulesList = modulesList.concat(extModules);
     }
 
@@ -259,8 +235,5 @@ module.exports = {
         if (!session.keepSource) {
             wrench.rmdirSyncRecursive(session.sourceDir);
         }
-    },
-    getFreeFeatures: function () {
-        return FREE_FEATURES;
     }
 };

--- a/lib/file-manager.js
+++ b/lib/file-manager.js
@@ -22,7 +22,12 @@ var path = require("path"),
     zip = require("zip"),
     localize = require("./localize"),
     CLIENT_JS = "client.js",
-    SERVER_JS = "index.js";
+    SERVER_JS = "index.js",
+    FREE_FEATURES = [{
+        version: "1.0.0.0",
+        required: true,
+        id: "blackberry.event"
+    }]; // the list of features that come for free, user does not need to whitelist manually
 
 function unzip(from, to) {
     var data, entries, p, parent;
@@ -95,18 +100,39 @@ function getModulesArray(dest, files, baseDir) {
     return modulesList;
 }
 
+function isFreeModule(path) {
+    var extId = /(\w+)\/([a-z.]+)\/([a-z.]+)/.exec(path)[2];
+    return FREE_FEATURES.reduce(
+        function (free, currFeature) {
+            return free || currFeature.id === extId;
+        },
+        false);
+}
+
 function generateFrameworkModulesJS(session) {
     var dest = session.sourcePaths,
         modulesList = [],
         modulesStr = "var frameworkModules = ",
         libFiles = wrench.readdirSyncRecursive(dest.LIB),
-        extFiles;
+        extFiles,
+        extModules,
+        freeModules;
 
     modulesList = modulesList.concat(getModulesArray(dest, libFiles, dest.LIB));
 
     if (path.existsSync(dest.EXT)) {
         extFiles = wrench.readdirSyncRecursive(dest.EXT);
-        modulesList = modulesList.concat(getModulesArray(dest, extFiles, dest.EXT));
+        extModules = getModulesArray(dest, extFiles, dest.EXT);
+        freeModules = extModules.filter(isFreeModule);
+        extModules = extModules.filter(function (path) {
+            return freeModules.indexOf(path) < 0;
+        });
+
+        // load extensions that need to be always available first
+        modulesList = modulesList.concat(freeModules);
+
+        // load other extensions
+        modulesList = modulesList.concat(extModules);
     }
 
     modulesStr += JSON.stringify(modulesList) + ";";
@@ -233,5 +259,8 @@ module.exports = {
         if (!session.keepSource) {
             wrench.rmdirSyncRecursive(session.sourceDir);
         }
+    },
+    getFreeFeatures: function () {
+        return FREE_FEATURES;
     }
 };

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -219,8 +219,8 @@ describe("xml parser", function () {
         configParser.parse(configPath, session, function (configObj) {
             customAccessList = testUtilities.getAccessListForUri(configObj.accessList, 'http://ci0000000094448.rim.net');
             
-            //The custom access list features should remain empty
-            expect(customAccessList.features).toEqual([]);
+            //The custom access list features should only contain free features
+            expect(customAccessList.features).toEqual(configParser.getFreeFeatures());
         });
     });
         
@@ -244,7 +244,7 @@ describe("xml parser", function () {
             //hasMultiAccess was set to false
             expect(configObj.hasMultiAccess).toEqual(false);
             expect(configObj.accessList).toEqual([ {
-                features : [],
+                features : configParser.getFreeFeatures(),
                 uri : 'WIDGET_LOCAL',
                 allowSubDomain : true
             } ]);
@@ -261,11 +261,11 @@ describe("xml parser", function () {
             //hasMultiAccess was set to false
             expect(configObj.hasMultiAccess).toEqual(false);
             expect(configObj.accessList).toEqual([ {
-                features : [],
+                features : configParser.getFreeFeatures(),
                 uri : 'WIDGET_LOCAL',
                 allowSubDomain : true
             }, {
-                "features" : [],
+                "features" : configParser.getFreeFeatures(),
                 "uri" : "http://www.somedomain1.com"
             } ]);
         });
@@ -281,7 +281,7 @@ describe("xml parser", function () {
             //hasMultiAccess was set to true
             expect(configObj.hasMultiAccess).toEqual(true);
             expect(configObj.accessList).toEqual([ {
-                features : [],
+                features : configParser.getFreeFeatures(),
                 uri : 'WIDGET_LOCAL',
                 allowSubDomain : true
             } ]);
@@ -298,11 +298,11 @@ describe("xml parser", function () {
             //hasMultiAccess was set to true
             expect(configObj.hasMultiAccess).toEqual(true);
             expect(configObj.accessList).toEqual([ {
-                features : [],
+                features : configParser.getFreeFeatures(),
                 uri : 'WIDGET_LOCAL',
                 allowSubDomain : true
             }, {
-                "features" : [],
+                "features" : configParser.getFreeFeatures(),
                 "uri" : "http://www.somedomain1.com"
             } ]);
         });

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -18,7 +18,7 @@ function mockParsing(data, error) {
     });
 }
 
-describe("xml parser", function () {
+describe("config parser", function () {
     it("parses standard elements in a config.xml", function () {
         configParser.parse(configPath, session, function (configObj) {
             expect(configObj.content).toEqual("local:///startPage.html");
@@ -219,8 +219,8 @@ describe("xml parser", function () {
         configParser.parse(configPath, session, function (configObj) {
             customAccessList = testUtilities.getAccessListForUri(configObj.accessList, 'http://ci0000000094448.rim.net');
             
-            //The custom access list features should only contain free features
-            expect(customAccessList.features).toEqual(fileManager.getFreeFeatures());
+            //The custom access list features should only contain global features
+            expect(customAccessList.features).toEqual(configParser.getGlobalFeatures());
         });
     });
         
@@ -244,7 +244,7 @@ describe("xml parser", function () {
             //hasMultiAccess was set to false
             expect(configObj.hasMultiAccess).toEqual(false);
             expect(configObj.accessList).toEqual([ {
-                features : fileManager.getFreeFeatures(),
+                features : configParser.getGlobalFeatures(),
                 uri : 'WIDGET_LOCAL',
                 allowSubDomain : true
             } ]);
@@ -261,11 +261,11 @@ describe("xml parser", function () {
             //hasMultiAccess was set to false
             expect(configObj.hasMultiAccess).toEqual(false);
             expect(configObj.accessList).toEqual([ {
-                features : fileManager.getFreeFeatures(),
+                features : configParser.getGlobalFeatures(),
                 uri : 'WIDGET_LOCAL',
                 allowSubDomain : true
             }, {
-                "features" : fileManager.getFreeFeatures(),
+                "features" : configParser.getGlobalFeatures(),
                 "uri" : "http://www.somedomain1.com"
             } ]);
         });
@@ -281,7 +281,7 @@ describe("xml parser", function () {
             //hasMultiAccess was set to true
             expect(configObj.hasMultiAccess).toEqual(true);
             expect(configObj.accessList).toEqual([ {
-                features : fileManager.getFreeFeatures(),
+                features : configParser.getGlobalFeatures(),
                 uri : 'WIDGET_LOCAL',
                 allowSubDomain : true
             } ]);
@@ -298,11 +298,11 @@ describe("xml parser", function () {
             //hasMultiAccess was set to true
             expect(configObj.hasMultiAccess).toEqual(true);
             expect(configObj.accessList).toEqual([ {
-                features : fileManager.getFreeFeatures(),
+                features : configParser.getGlobalFeatures(),
                 uri : 'WIDGET_LOCAL',
                 allowSubDomain : true
             }, {
-                "features" : fileManager.getFreeFeatures(),
+                "features" : configParser.getGlobalFeatures(),
                 "uri" : "http://www.somedomain1.com"
             } ]);
         });

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -188,7 +188,6 @@ describe("xml parser", function () {
 
         spyOn(logger, "error");
         spyOn(fileManager, "cleanSource");
-        spyOn(fileManager, "copyWWE");
 
         configParser.parse(configPath, session, function () {});
         

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -185,10 +185,11 @@ describe("xml parser", function () {
     
     it("cleans source folder on error", function () {
         mockParsing({}, "ERROR");
-        
+
         spyOn(logger, "error");
         spyOn(fileManager, "cleanSource");
-        
+        spyOn(fileManager, "copyWWE");
+
         configParser.parse(configPath, session, function () {});
         
         expect(fileManager.cleanSource).toHaveBeenCalled();
@@ -220,7 +221,7 @@ describe("xml parser", function () {
             customAccessList = testUtilities.getAccessListForUri(configObj.accessList, 'http://ci0000000094448.rim.net');
             
             //The custom access list features should only contain free features
-            expect(customAccessList.features).toEqual(configParser.getFreeFeatures());
+            expect(customAccessList.features).toEqual(fileManager.getFreeFeatures());
         });
     });
         
@@ -244,7 +245,7 @@ describe("xml parser", function () {
             //hasMultiAccess was set to false
             expect(configObj.hasMultiAccess).toEqual(false);
             expect(configObj.accessList).toEqual([ {
-                features : configParser.getFreeFeatures(),
+                features : fileManager.getFreeFeatures(),
                 uri : 'WIDGET_LOCAL',
                 allowSubDomain : true
             } ]);
@@ -261,11 +262,11 @@ describe("xml parser", function () {
             //hasMultiAccess was set to false
             expect(configObj.hasMultiAccess).toEqual(false);
             expect(configObj.accessList).toEqual([ {
-                features : configParser.getFreeFeatures(),
+                features : fileManager.getFreeFeatures(),
                 uri : 'WIDGET_LOCAL',
                 allowSubDomain : true
             }, {
-                "features" : configParser.getFreeFeatures(),
+                "features" : fileManager.getFreeFeatures(),
                 "uri" : "http://www.somedomain1.com"
             } ]);
         });
@@ -281,7 +282,7 @@ describe("xml parser", function () {
             //hasMultiAccess was set to true
             expect(configObj.hasMultiAccess).toEqual(true);
             expect(configObj.accessList).toEqual([ {
-                features : configParser.getFreeFeatures(),
+                features : fileManager.getFreeFeatures(),
                 uri : 'WIDGET_LOCAL',
                 allowSubDomain : true
             } ]);
@@ -298,11 +299,11 @@ describe("xml parser", function () {
             //hasMultiAccess was set to true
             expect(configObj.hasMultiAccess).toEqual(true);
             expect(configObj.accessList).toEqual([ {
-                features : configParser.getFreeFeatures(),
+                features : fileManager.getFreeFeatures(),
                 uri : 'WIDGET_LOCAL',
                 allowSubDomain : true
             }, {
-                "features" : configParser.getFreeFeatures(),
+                "features" : fileManager.getFreeFeatures(),
                 "uri" : "http://www.somedomain1.com"
             } ]);
         });

--- a/test/unit/lib/file-manager.js
+++ b/test/unit/lib/file-manager.js
@@ -146,16 +146,28 @@ describe("File manager", function () {
     });
 
     it("generateFrameworkModulesJS() should create frameworkModules.js", function () {
-        var files = [],
+        var libFiles = [],
+            extFiles = [],
             modulesArr;
 
-        files.push(path.normalize(session.sourcePaths.CHROME + "/lib/framework.js"));
-        files.push(path.normalize(session.sourcePaths.CHROME + "/lib/config/user.js"));
-        files.push(path.normalize(session.sourcePaths.CHROME + "/lib/plugins/bridge.js"));
-        files.push(path.normalize(session.sourcePaths.CHROME + "/lib/policy/whitelist.js"));
-        files.push(path.normalize(session.sourcePaths.CHROME + "/ext/blackberry.app/client.js"));
+        libFiles.push(path.normalize(session.sourcePaths.CHROME + "/lib/framework.js"));
+        libFiles.push(path.normalize(session.sourcePaths.CHROME + "/lib/config/user.js"));
+        libFiles.push(path.normalize(session.sourcePaths.CHROME + "/lib/plugins/bridge.js"));
+        libFiles.push(path.normalize(session.sourcePaths.CHROME + "/lib/policy/whitelist.js"));
+        extFiles.push(path.normalize(session.sourcePaths.CHROME + "/ext/blackberry.app/client.js"));
+        extFiles.push(path.normalize(session.sourcePaths.CHROME + "/ext/blackberry.app/index.js"));
+        extFiles.push(path.normalize(session.sourcePaths.CHROME + "/ext/blackberry.connection/client.js"));
+        extFiles.push(path.normalize(session.sourcePaths.CHROME + "/ext/blackberry.connection/index.js"));        
+        extFiles.push(path.normalize(session.sourcePaths.CHROME + "/ext/blackberry.event/client.js"));
+        extFiles.push(path.normalize(session.sourcePaths.CHROME + "/ext/blackberry.event/index.js"));        
 
-        spyOn(wrench, "readdirSyncRecursive").andReturn(files);
+        spyOn(wrench, "readdirSyncRecursive").andCallFake(function (path) {
+            if (/ext$/.test(path)) {
+                return extFiles;
+            } else {
+                return libFiles;
+            }
+        });
         spyOn(fs, "statSync").andReturn({
             isDirectory: function () {
                 return false;
@@ -175,7 +187,10 @@ describe("File manager", function () {
         expect(modulesArr).toContain("lib/config/user.js");
         expect(modulesArr).toContain("lib/plugins/bridge.js");
         expect(modulesArr).toContain("lib/policy/whitelist.js");
-        expect(modulesArr).toContain("ext/blackberry.app/client.js");
+        expect(modulesArr).toContain("ext/blackberry.event/index.js");
+        // checks that blackberry.event is loaded before any other extensions
+        expect(modulesArr.indexOf("ext/blackberry.event/index.js")).toBeLessThan(modulesArr.indexOf("ext/blackberry.app/index.js"));
+        expect(modulesArr.indexOf("ext/blackberry.event/index.js")).toBeLessThan(modulesArr.indexOf("ext/blackberry.connection/index.js"));
     });
 
     it("unzip() should extract 'from' zip file to 'to' directory", function () {

--- a/test/unit/lib/file-manager.js
+++ b/test/unit/lib/file-manager.js
@@ -188,9 +188,6 @@ describe("File manager", function () {
         expect(modulesArr).toContain("lib/plugins/bridge.js");
         expect(modulesArr).toContain("lib/policy/whitelist.js");
         expect(modulesArr).toContain("ext/blackberry.event/index.js");
-        // checks that blackberry.event is loaded before any other extensions
-        expect(modulesArr.indexOf("ext/blackberry.event/index.js")).toBeLessThan(modulesArr.indexOf("ext/blackberry.app/index.js"));
-        expect(modulesArr.indexOf("ext/blackberry.event/index.js")).toBeLessThan(modulesArr.indexOf("ext/blackberry.connection/index.js"));
     });
 
     it("unzip() should extract 'from' zip file to 'to' directory", function () {


### PR DESCRIPTION
- Make blackberry.event always available even if the developer did not whitelist it
- Make sure blackberry.event gets loaded before any other extensions get loaded

Framework Pull Request: blackberry-webworks/BB10-WebWorks-Framework#37 <-- this pull request to be closed AFTER the framework pull request is closed, the Framework submodule needs to point to the right commit

Docs Pull Request: blackberry-webworks/WebWorks-API-Docs#118
