### PR TITLE
Next fix61 topleveldomain

### DIFF
--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -254,6 +254,15 @@ function validateConfig(widgetConfig) {
     if (widgetConfig.icon) {
         check(widgetConfig.icon, localize.translate("EXCEPTION_INVALID_ICON_SRC")).notNull();
     }
+
+    if (widgetConfig.accessList) {
+        widgetConfig.accessList.forEach(function (access) {
+            if (access.uri) {
+                check(access.uri, localize.translate("EXCEPTION_INVALID_ACCESS_URI_TOP_LEVEL_DOMAIN", access.uri))
+                    .notRegex("^[a-zA-Z]+:\/\/[a-zA-Z]+$");
+            }
+        });
+    }
 }
 
 function processResult(data, session) {

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -90,6 +90,9 @@ var Localize = require("localize"),
         },
         "EXCEPTION_FEATURE_DEFINED_WITH_WILDCARD_ACCESS_URI": {
             "en": "Invalid config.xml - no <feature> tags are allowed for this <access> element"
+        },
+        "EXCEPTION_INVALID_ACCESS_URI_TOP_LEVEL_DOMAIN": {
+            "en": "Invalid config.xml - the URI attribute in the access element specifies a top-levl domain($[1])"
         }
     }, "", ""); // TODO maybe a bug in localize, must set default locale to "" in order get it to work
 

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -92,7 +92,7 @@ var Localize = require("localize"),
             "en": "Invalid config.xml - no <feature> tags are allowed for this <access> element"
         },
         "EXCEPTION_INVALID_ACCESS_URI_TOP_LEVEL_DOMAIN": {
-            "en": "Invalid config.xml - the URI attribute in the access element specifies a top-levl domain($[1])"
+            "en": "Invalid config.xml - the URI attribute in the access element specifies a top-level domain($[1])"
         }
     }, "", ""); // TODO maybe a bug in localize, must set default locale to "" in order get it to work
 

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -329,7 +329,28 @@ describe("config parser", function () {
             configParser.parse(configPath, session, function (configObj) {});
         }).toThrow(localize.translate("EXCEPTION_FEATURE_DEFINED_WITH_WILDCARD_ACCESS_URI"));
     });
-    
+
+    it("should fail when the access uri attribute specifies a top level domain", function () {
+        var data = testUtilities.cloneObj(testData.xml2jsConfig);
+
+        //Add an access element with one feature
+        data['access'] = {
+            '@': {
+                uri: "http://com",
+                subdomains: 'true'
+            },
+            feature: {
+                '@': { id: 'blackberry.system' }
+            }
+        };
+
+        mockParsing(data);
+
+        expect(function () {
+            configParser.parse(configPath, session, function (configObj) {});
+        }).toThrow(localize.translate("EXCEPTION_INVALID_ACCESS_URI_TOP_LEVEL_DOMAIN", data["access"]["@"].uri));
+    });
+
     it("does not fail when there is a single feature element in the access list", function () {
         var data = testUtilities.cloneObj(testData.xml2jsConfig);
         


### PR DESCRIPTION
The issue related to this bug fix is blackberry/BB10-Webworks-Packager#61

Changed the packager so that it throws an exception if a user specifies a top level domain in the access uri attribue 
