### PR TITLE
Next fix63 accessuri nourn

### DIFF
--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -254,6 +254,15 @@ function validateConfig(widgetConfig) {
     if (widgetConfig.icon) {
         check(widgetConfig.icon, localize.translate("EXCEPTION_INVALID_ICON_SRC")).notNull();
     }
+
+    if (widgetConfig.accessList) {
+        widgetConfig.accessList.forEach(function (access) {
+            if (access.uri) {
+                check(access.uri, localize.translate("EXCEPTION_INVALID_ACCESS_URI_NO_URN", access.uri))
+                    .notRegex("^[a-zA-Z]+:\/\/$");
+            }
+        });
+    }
 }
 
 function processResult(data, session) {

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -90,6 +90,9 @@ var Localize = require("localize"),
         },
         "EXCEPTION_FEATURE_DEFINED_WITH_WILDCARD_ACCESS_URI": {
             "en": "Invalid config.xml - no <feature> tags are allowed for this <access> element"
+        },
+        "EXCEPTION_INVALID_ACCESS_URI_NO_URN": {
+            "en": "Failed to parse the URI attribute in the access element($[1])"
         }
     }, "", ""); // TODO maybe a bug in localize, must set default locale to "" in order get it to work
 

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -329,7 +329,28 @@ describe("config parser", function () {
             configParser.parse(configPath, session, function (configObj) {});
         }).toThrow(localize.translate("EXCEPTION_FEATURE_DEFINED_WITH_WILDCARD_ACCESS_URI"));
     });
-    
+
+    it("should fail when the access uri attribute does not specify a URN", function () {
+        var data = testUtilities.cloneObj(testData.xml2jsConfig);
+
+        //Add an access element with one feature
+        data['access'] = {
+            '@': {
+                uri: 'http://',
+                subdomains: 'true'
+            },
+            feature: {
+                '@': { id: 'blackberry.system' }
+            }
+        };
+
+        mockParsing(data);
+
+        expect(function () {
+            configParser.parse(configPath, session, function (configObj) {});
+        }).toThrow(localize.translate("EXCEPTION_INVALID_ACCESS_URI_NO_URN", data['access']['@'].uri));
+    });
+
     it("does not fail when there is a single feature element in the access list", function () {
         var data = testUtilities.cloneObj(testData.xml2jsConfig);
         


### PR DESCRIPTION
The fix related to this bug fix is blackberry/BB10-Webworks-Packager#63

Made the packager fail if the access uri attribute does not specify a URN.
