### PR TITLE
Fixed issue #104:  packager output in incorrect directory

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -29,8 +29,8 @@ module.exports = {
             archiveName = path.basename(archivePath, '.zip'),
             buildId = cmdline.buildId;
 
-        //If -o option was not provided, default output location is the current directory
-        outputDir = outputDir || process.cwd();
+        //If -o option was not provided, default output location is the same as .zip
+        outputDir = outputDir || path.dirname(archivePath);
 
         //Only set signingPassword if it contains a value
         if (cmdline.password && "string" === typeof cmdline.password) {

--- a/test/unit/lib/session.js
+++ b/test/unit/lib/session.js
@@ -54,7 +54,7 @@ describe("Session", function () {
         result = session.initialize(data);
         
         //src folder should be created in output directory
-        expect(result.sourceDir).toEqual(path.join(process.cwd(), "src"));
+        expect(result.sourceDir).toEqual(path.join(path.dirname(zipLocation), "src"));
     });
     
     it("sets the password when specified using -g", function () {


### PR DESCRIPTION
Fixes issue #104 (blackberry/BB10-Webworks-Packager/issues/104)

Packager now places output bar files into the directory of the .zip, by default.
