### PR TITLE
Throws error if invalid multi-word argument passed into packager

### DIFF
--- a/lib/bbwp.js
+++ b/lib/bbwp.js
@@ -28,7 +28,7 @@ var path = require("path"),
 
 try {
     cmdline.parse(process.argv);
-    session = require("./session").initialize(cmdline);
+    session = require("./session").initialize(cmdline.commander);
     
     //prepare files for webworks archiving
     logger.info(localize.translate("PROGRESS_FILE_POPULATING_SOURCE"));

--- a/lib/cmdline.js
+++ b/lib/cmdline.js
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-var cmd = require("commander"),
-    logger = require("./logger");
+var command = require("commander"),
+    logger = require("./logger"),
+    localize = require("./localize");
 
-cmd
+command
     .version('1.0.0.0')
     .usage('[drive:][path]archive [-s [dir]] [[ -g genpassword] [-buildId num]] [-o dir] [-d]')
     .option('-s, --source [dir]', 'Save source. The default behaviour is to not save the source files. If dir is specified then creates dir\\src\\ directory structure. If no dir specified then the path of archive is assumed')
@@ -28,16 +29,36 @@ cmd
     .option('-d, --debug', 'Allows use of not signed build on device by utilizing debug token and enables Web Inspector.')
     .option('-v, --verbose', 'Turn on verbose messages');
 
-if (!process.argv[2]) {
-    //no args passed into [node bbwp.js], show the help information
-    process.argv.push("-h");
+function parseArgs(args) {
+    var option,
+        i;
+    if (!args[2]) {
+        //no args passed into [node bbwp.js], show the help information
+        args.push("-h");
+    }
+
+    //Handle deprecated option -buildId
+    for (i = 0; i < args.length; i++) {
+        if (args[i] === "-buildId") {
+            args[i] = "--buildId";
+        }
+    }
+    
+    command.parse(args);
+
+    //Check for any invalid command line args
+    for (i = 0; i < args.length; i++) {
+        //Remove leading dashes if any
+        option = args[i].substring(2);
+        if (args[i].indexOf("--") === 0 && !command[option]) {
+            throw localize.translate("EXCEPTION_CMDLINE_ARG_INVALID", args[i]);
+        }
+    }
+
+    return this;
 }
 
-//Handle deprecated option -buildId
-for (var i = 0; i < process.argv.length; i++) {
-    if (process.argv[i] === "-buildId") {
-        process.argv[i] = "--buildId";
-    }
-}
-    
-module.exports = cmd;
+module.exports = {
+    "commander": command,
+    "parse": parseArgs
+};

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -96,6 +96,9 @@ var Localize = require("localize"),
         },
         "EXCEPTION_INVALID_ACCESS_URI_NO_URN": {
             "en": "Failed to parse the URI attribute in the access element($[1])"
+        },
+        "EXCEPTION_CMDLINE_ARG_INVALID": {
+            "en": "Invalid command line argument \"$[1]\""
         }
     }, "", ""); // TODO maybe a bug in localize, must set default locale to "" in order get it to work
 

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,6 @@
                             <executable>jake</executable>
                             <workingDirectory></workingDirectory>            
                             <arguments>
-                                <argument>--trace</argument>
                                 <argument>test</argument>
                             </arguments>
                                 <successCodes>
@@ -145,7 +144,6 @@
                             <executable>jake</executable>
                             <workingDirectory></workingDirectory>            
                             <arguments>
-                                <argument>--trace</argument>
                                 <argument>lint</argument>
                             </arguments>
                             <successCodes>
@@ -162,7 +160,6 @@
                         <configuration>
                             <executable>jake</executable>      
                             <arguments>
-                                <argument>--trace</argument>
                                 <argument>build</argument>
                             </arguments>
                             <successCodes>

--- a/test/unit/lib/cmdline.js
+++ b/test/unit/lib/cmdline.js
@@ -1,9 +1,13 @@
 var srcPath = __dirname + "/../../../lib/",
+    localize = require(srcPath + "localize"),
+    cmdline = require(srcPath + "cmdline"),
     cmd;
 
 describe("Command line", function () {
     beforeEach(function () {
-        cmd = require(srcPath + "cmdline");
+        cmd = cmdline
+                .parse(process.argv)
+                .commander;
     });
 
     it("accepts -o with argument", function () {
@@ -53,4 +57,11 @@ describe("Command line", function () {
         cmd.parseOptions(["-buildId", "100"]);
         expect(cmd.buildId).toEqual("100");
     });
+
+    it("throws an error for invalid multi-word arguments", function () {
+        expect(function () {
+            require(srcPath + "cmdline").parse(["--src"]);
+        }).toThrow(localize.translate("EXCEPTION_CMDLINE_ARG_INVALID", "--src"));
+    });
+
 });


### PR DESCRIPTION
The issue related to this bug fix is:

blackberry/BB10-Webworks-Packager#138

I made the packager throw an error if a user passes an invalid multi-word command line argument

@EricLeiLi could you please do a code review?
