### PR TITLE
Fix test case in extension manager 

### DIFF
--- a/test/unit/lib/extension-manager.js
+++ b/test/unit/lib/extension-manager.js
@@ -15,6 +15,8 @@ function loadModule(module) {
         namespace,
         dependencies = [];
 
+    module = module.split(path.sep);
+
     if (module.indexOf("app") >= 0) {
         namespace = "blackberry.app";
     } else if (module.indexOf("event") >= 0) {


### PR DESCRIPTION
Fix issue introducted in extension-manager where the working dir path name can affect test case.

`module.indexOf("app")` would equate to true if `module = "/application/BB10-WebWorks-Packager/ext/event/manifest.json"`

CI builds fail if the branch name has a extension name as a substring. 

@rwmtse 
