### PR TITLE
Pull Request: Updates packager with new version supports card as application type.

### DIFF
--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -412,8 +412,7 @@ function validateConfig(widgetConfig) {
                 .notEmpty();
             check(invokeTarget.type, localize.translate("EXCEPTION_INVOKE_TARGET_INVALID_TYPE"))
                 .notNull()
-                .notEmpty()
-                .isIn(["APPLICATION", "VIEWER"]);
+                .notEmpty();
 
             if (invokeTarget.filter) {
 
@@ -432,8 +431,6 @@ function validateConfig(widgetConfig) {
                             check(property["@"] && property["@"]["var"] && typeof property["@"]["var"] === "string",
                                     localize.translate("EXCEPTION_INVOKE_TARGET_FILTER_PROPERTY_INVALID"))
                                 .equals(true);
-                            check(property["@"]["var"], localize.translate("EXCEPTION_INVOKE_TARGET_FILTER_PROPERTY_INVALID"))
-                                .isIn(["exts", "uris"]);
                         });
                     }
                 });

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -107,7 +107,7 @@ var Localize = require("localize"),
             "en": "Each rim:invoke-target element must specify a valid id attribute"
         },
         "EXCEPTION_INVOKE_TARGET_INVALID_TYPE": {
-            "en": "Each rim:invoke-target element must specify a valid type."
+            "en": "rim:invoke-target element must be specified and cannot be empty"
         },
         "EXCEPTION_INVOKE_TARGET_ACTION_INVALID": {
             "en": "Each filter element must specify at least one valid action"

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
                                 <artifactItem>
                                     <groupId>net.rim.BBXwebworks</groupId>
                                     <artifactId>packager-bin</artifactId>
-                                    <version>1.0.0.19</version>
+                                    <version>1.0.0.22</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
                                 </artifactItem>

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -597,22 +597,6 @@ describe("config parser", function () {
         }).toThrow(localize.translate("EXCEPTION_INVOKE_TARGET_INVALID_TYPE"));
     });
 
-    it("throws an error when an invoke target specifies an invalid invocation type", function () {
-        var data = testUtilities.cloneObj(testData.xml2jsConfig);
-        data["rim:invoke-target"] = {
-            "@": {
-                "id": "com.domain.subdomain.appName.app"
-            },
-            "type": "myInvokeType"
-        };
-
-        mockParsing(data);
-
-        expect(function () {
-            configParser.parse(configPath, session, extManager, function (configObj) {});
-        }).toThrow(localize.translate("EXCEPTION_INVOKE_TARGET_INVALID_TYPE"));
-    });
-
     it("throws an error when an invoke target filter doesn't contain an action",  function () {
         var data = testUtilities.cloneObj(testData.xml2jsConfig);
         data["rim:invoke-target"] = {


### PR DESCRIPTION
Removed validation for application types (_application_ and _viewer_) and filter attributes (_exts_ and _uris_).
Also it has Framework submodule with corresponding changes.

More info [here](https://github.com/blackberry-webworks/WebWorks-API-Docs/pull/138)
User story mentions this issue [link](https://github.com/blackberry/BB10-Webworks-Packager/issues/112) but no card are mentioned there.

[JSDoc](http://blackberry-webworks.github.com/WebWorks-API-Docs/WebWorks-API-Docs-next-BB10-cards/view/index.html). 
[CI Build](http://ci0000003863287:8080/hudson/job/BB10-Webworks-Packager-next-adds-card-invocation-support/4/)
