### PR TITLE
Removed references to BBX from repo:

### DIFF
--- a/lib/conf.js
+++ b/lib/conf.js
@@ -25,7 +25,6 @@ module.exports = {
     DEPENDENCIES: path.normalize(__dirname + "/../Framework/dependencies"),
     DEPENDENCIES_BOOTSTRAP: path.normalize(__dirname + "/../Framework/dependencies/bootstrap"),
     DEPENDENCIES_TOOLS: path.normalize(__dirname + "/../dependencies/tools"),
-    DEPENDENCIES_EMU: path.normalize(__dirname + "/../Framework/dependencies/BBX-Emulator"),
     DEPENDENCIES_WWE: path.normalize(__dirname + "/../dependencies/%s-wwe"),
     DEPENDENCIES_BAR: path.normalize(__dirname + "/../dependencies/bar-dependencies/%s"),
     DEBUG_TOKEN: path.normalize(__dirname + "/../debugtoken.bar"),

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>net.rim.BBXwebworks</groupId>
+    <groupId>net.rim.BB10webworks</groupId>
     <artifactId>BB10webworks</artifactId>
     <version>1.0.0.0</version>
     <name>${project.artifactId}-${project.version}</name>
@@ -183,7 +183,7 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>net.rim.BBXwebworks</groupId>
+                                    <groupId>net.rim.BB10webworks</groupId>
                                     <artifactId>packager-bin</artifactId>
                                     <version>1.0.0.23</version>
                                     <type>zip</type>
@@ -201,7 +201,7 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>net.rim.BBXwebworks</groupId>
+                                    <groupId>net.rim.BB10webworks</groupId>
                                     <artifactId>bar-dependencies</artifactId>
                                     <version>1.0.0.3</version>
                                     <type>zip</type>


### PR DESCRIPTION
Removed references to BBX from the repo. Also removed references in the Framework and Webplatform repos.

Fixes issues:
- blackberry/BB10-WebWorks-Framework#90
- blackberry/BB10-Webworks-Packager#100
