### PR TITLE
Fixes blackberry/BB10-Webworks-Packager#120 packager throws exception if archive name not valid

### DIFF
--- a/lib/cmdline.js
+++ b/lib/cmdline.js
@@ -44,7 +44,7 @@ function parseArgs(args) {
             args[i] = "--buildId";
         }
     }
-    
+
     command.parse(args);
 
     //Check for any invalid command line args
@@ -53,6 +53,10 @@ function parseArgs(args) {
         option = args[i].substring(2);
         if (args[i].indexOf("--") === 0 && !command[option]) {
             throw localize.translate("EXCEPTION_CMDLINE_ARG_INVALID", args[i]);
+        }  //Test if archive ends with ".zip"
+        else if (args[i].indexOf(".zip") !== -1 &&
+                    args[i].indexOf(".zip") !== args[i].length - 4) {
+            throw localize.translate("EXCEPTION_INVALID_ARCHIVE", args[i]);
         }
     }
 

--- a/lib/cmdline.js
+++ b/lib/cmdline.js
@@ -32,6 +32,7 @@ command
 
 function parseArgs(args) {
     var option,
+        archiveRegExp = /^[a-zA-Z][a-zA-Z0-9]*\.zip$/,
         i;
     if (!args[2]) {
         //no args passed into [node bbwp.js], show the help information
@@ -55,7 +56,7 @@ function parseArgs(args) {
             throw localize.translate("EXCEPTION_CMDLINE_ARG_INVALID", args[i]);
         }  //Test if archive ends with ".zip"
         else if (args[i].indexOf(".zip") !== -1 &&
-                    args[i].indexOf(".zip") !== args[i].length - 4) {
+                   ! archiveRegExp.test(args[i])) {
             throw localize.translate("EXCEPTION_INVALID_ARCHIVE", args[i]);
         }
     }

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -150,6 +150,9 @@ var Localize = require("localize"),
         },
         "EXCEPTION_PARAMS_FILE_NOT_FOUND": {
             "en": "\"$[1]\" does not exist"
+        },
+        "EXCEPTION_INVALID_ARCHIVE": {
+            "en": "\"$[1]\" is not a valid archive name"
         }
     }, "", ""); // TODO maybe a bug in localize, must set default locale to "" in order get it to work
 

--- a/test/unit/lib/cmdline.js
+++ b/test/unit/lib/cmdline.js
@@ -42,17 +42,17 @@ describe("Command line", function () {
         cmd.parseOptions(["-v"]);
         expect(cmd.verbose).toBeTruthy();
     });
-    
+
     it("accepts -g with argument", function () {
         cmd.parseOptions(["-g", "myPassword"]);
         expect(cmd.password).toEqual("myPassword");
     });
-    
+
     it("accepts --buildId with argument", function () {
         cmd.parseOptions(["--buildId", "100"]);
         expect(cmd.buildId).toEqual("100");
     });
-    
+
     it("accepts -buildId with argument", function () {
         cmd.parseOptions(["-buildId", "100"]);
         expect(cmd.buildId).toEqual("100");
@@ -64,4 +64,9 @@ describe("Command line", function () {
         }).toThrow(localize.translate("EXCEPTION_CMDLINE_ARG_INVALID", "--src"));
     });
 
+    it("throws an error if the archive name is not valid", function () {
+        expect(function () {
+            require(srcPath + "cmdline").parse(["archive.zip.zip"]);
+        }).toThrow(localize.translate("EXCEPTION_INVALID_ARCHIVE", "archive.zip.zip"));
+    });
 });


### PR DESCRIPTION
This fix will make the packager throw an error if the archive name end with ".zip.zip". It aligns the behavior of the BB10 packager with snarf

Fixes blackberry/BB10-Webworks-Packager#120
