### PR TITLE
Removed bar-dependencies + added support for jnext dependencies in repo

### DIFF
--- a/lib/bar-builder.js
+++ b/lib/bar-builder.js
@@ -29,15 +29,15 @@ function buildTarget(previous, baton) {
     var target = this.session.targets[targetIdx++],
         session = this.session,
         config = this.config;
-    
+
     //Create output folder
     wrench.mkdirSyncRecursive(session.outputDir + "/" + target);
-    
+
     //Copy target dependent files
     fileManager.copyWWE(this.session, target);
-    fileManager.copyBarDependencies(this.session, target);
+    fileManager.copyJnextDependencies(this.session);
     fileManager.copyExtensions(this.config.accessList, this.session, target, this.extManager);
-    
+
     //Generate frameworkModules.js (this needs to be done AFTER all files have been copied)
     fileManager.generateFrameworkModulesJS(session);
 

--- a/lib/conf.js
+++ b/lib/conf.js
@@ -24,9 +24,9 @@ module.exports = {
     UI: path.normalize(__dirname + "/../Framework/ui-resources"),
     DEPENDENCIES: path.normalize(__dirname + "/../Framework/dependencies"),
     DEPENDENCIES_BOOTSTRAP: path.normalize(__dirname + "/../Framework/dependencies/bootstrap"),
+    DEPENDENCIES_JNEXT: path.normalize(__dirname + "/../Framework/dependencies/jnext"),
     DEPENDENCIES_TOOLS: path.normalize(__dirname + "/../dependencies/tools"),
     DEPENDENCIES_WWE: path.normalize(__dirname + "/../dependencies/%s-wwe"),
-    DEPENDENCIES_BAR: path.normalize(__dirname + "/../dependencies/bar-dependencies/%s"),
     DEBUG_TOKEN: path.normalize(__dirname + "/../debugtoken.bar"),
     DEFAULT_ICON: path.normalize(__dirname + "/../default-icon.png")
 };

--- a/lib/file-manager.js
+++ b/lib/file-manager.js
@@ -133,16 +133,16 @@ function copyWWE(session, target) {
     fs.copySync(src, dest);
 }
 
-function copyBarDependencies(session, target) {
+function copyJnextDependencies(session) {
     var conf = session.conf,
-        src = path.normalize(util.format(conf.DEPENDENCIES_BAR, target)),
-        dest = path.normalize(session.sourcePaths.PLUGINS);
+        src = path.normalize(conf.DEPENDENCIES_JNEXT),
+        dest = path.normalize(session.sourcePaths.JNEXT_PLUGINS);
 
     if (!path.existsSync(dest)) {
         wrench.mkdirSyncRecursive(dest, "0755");
     }
 
-    wrench.copyDirSyncRecursive(src, session.sourcePaths.PLUGINS);
+    wrench.copyDirSyncRecursive(src, dest);
 }
 
 function checkMissingFileInAPIFolder(apiDir, fileToCheck) {
@@ -247,7 +247,7 @@ module.exports = {
 
     copyWWE: copyWWE,
 
-    copyBarDependencies: copyBarDependencies,
+    copyJnextDependencies: copyJnextDependencies,
 
     prepareOutputFiles: prepare,
 

--- a/pom.xml
+++ b/pom.xml
@@ -192,24 +192,6 @@
                             </artifactItems>
                         </configuration>
                   </execution>
-                  <execution>
-                        <id>unpack-bar-dependencies</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>net.rim.BB10webworks</groupId>
-                                    <artifactId>bar-dependencies</artifactId>
-                                    <version>1.0.0.3</version>
-                                    <type>zip</type>
-                                    <overWrite>true</overWrite>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                  </execution>
                 </executions>
             </plugin>
 

--- a/test/unit/lib/bar-builder.js
+++ b/test/unit/lib/bar-builder.js
@@ -17,7 +17,7 @@ describe("BAR builder", function () {
 
         spyOn(wrench, "mkdirSyncRecursive");
         spyOn(fileMgr, "copyWWE");
-        spyOn(fileMgr, "copyBarDependencies");
+        spyOn(fileMgr, "copyJnextDependencies");
         spyOn(fileMgr, "copyExtensions");
         spyOn(fileMgr, "generateFrameworkModulesJS");
         spyOn(nativePkgr, "exec").andCallFake(function (session, target, config, callback) {
@@ -28,7 +28,7 @@ describe("BAR builder", function () {
 
         expect(wrench.mkdirSyncRecursive).toHaveBeenCalledWith(session.outputDir + "/" + target);
         expect(fileMgr.copyWWE).toHaveBeenCalledWith(session, target);
-        expect(fileMgr.copyBarDependencies).toHaveBeenCalledWith(session, target);
+        expect(fileMgr.copyJnextDependencies).toHaveBeenCalledWith(session);
         expect(fileMgr.copyExtensions).toHaveBeenCalledWith(config.accessList, session, target, extManager);
         expect(fileMgr.generateFrameworkModulesJS).toHaveBeenCalledWith(session);
         expect(nativePkgr.exec).toHaveBeenCalledWith(session, target, config, jasmine.any(Function));


### PR DESCRIPTION
Removed bar-dependencies maven artifact + added support for jnext dependencies in repo (auth.txt)

When testing please ensure you use trunk. A recent change is required.
