### PR TITLE
Implemented orientation locking support + support for "hybrid" features

### DIFF
--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -542,7 +542,13 @@ function init() {
                     bgColor = params.backgroundColor;
 
                 if (bgColor) {
-                    widgetConfig.backgroundColor = bgColor;
+                    try {
+                        //Convert bgColor to a number
+                        widgetConfig.backgroundColor = parseInt(bgColor, 16);
+                    } catch (err) {
+                        //bgcolor is not a number, throw error
+                        throw localize.translate("EXCEPTION_BGCOLOR_INVALID");
+                    }
                 }
             }
         }

--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -28,10 +28,19 @@ var fs = require("fsext"),
     i18nMgr = require("./i18n-manager"),
     _self,
     _predefinedFeatures = {
-        "enable-flash" : function enableFlashFeature(attribs, widgetConfig) {
+        "enable-flash" : function enableFlashFeature(feature, widgetConfig) {
             widgetConfig.enableFlash = true;
-        }
+        },
+        "blackberry.app.orientation": function orientationFeature(feature, widgetConfig) {
+            if (feature) {
+                var mode = feature.mode ? feature.mode.toLowerCase() : undefined;
 
+                if (mode && mode === "landscape" || mode === "portrait") {
+                    widgetConfig.autoOrientation = false;
+                    widgetConfig.orientation = mode;//Overwrites default value
+                }
+            }
+        }
     };
 
 function processFeatures(featuresArray, widgetConfig, extManager, processPredefinedFeatures) {
@@ -47,7 +56,7 @@ function processFeatures(featuresArray, widgetConfig, extManager, processPredefi
                 //Check for predefined features that do not have source code
                 if (_predefinedFeatures[attribs.id]) {
                     if (processPredefinedFeatures) {
-                        _predefinedFeatures[attribs.id](attribs, widgetConfig);
+                        _predefinedFeatures[attribs.id](feature, widgetConfig);
                     }
                 } else {
                     features.push(attribs);
@@ -109,9 +118,11 @@ function processWidgetData(data, widgetConfig, session, extManager) {
         widgetConfig.id = data["@"].id;
     }
 
-    widgetConfig.hasMultiAccess = false; // Default value of hasMultiAccess is false
+    //Default values
+    widgetConfig.hasMultiAccess = false;
     widgetConfig.accessList = [];
-    widgetConfig.enableFlash = false;// Default value for flash support is false
+    widgetConfig.enableFlash = false;
+    widgetConfig.autoOrientation = true;
 
     //set locally available features to access list
     if (data.feature) {
@@ -311,21 +322,6 @@ function processContentData(data, widgetConfig) {
     }
 }
 
-function processOrientationData(data, widgetConfig) {
-    if (data["rim:orientation"] && data["rim:orientation"]["@"]) {
-        var mode = data["rim:orientation"]["@"].mode;
-
-        if (mode === "landscape" || mode === "portrait") {
-            widgetConfig.autoOrientation = false;
-            widgetConfig.orientation = mode;
-            return;
-        }
-    }
-    
-    //Default value
-    widgetConfig.autoOrientation = true;
-}
-
 function processPermissionsData(data, widgetConfig) {
     if (data["rim:permissions"] && data["rim:permissions"]["rim:permit"]) {
         var permissions = data["rim:permissions"]["rim:permit"];
@@ -473,7 +469,6 @@ function processResult(data, session, extManager) {
     processAuthorData(data, widgetConfig);
     processLicenseData(data, widgetConfig);
     processContentData(data, widgetConfig);
-    processOrientationData(data, widgetConfig);
     processPermissionsData(data, widgetConfig);
     processInvokeTargetsData(data, widgetConfig);
     processSplashScreenData(data, widgetConfig);

--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -33,11 +33,14 @@ var fs = require("fsext"),
         },
         "blackberry.app.orientation": function orientationFeature(feature, widgetConfig) {
             if (feature) {
-                var mode = feature.mode ? feature.mode.toLowerCase() : undefined;
+                var mode = feature.mode;
 
-                if (mode && mode === "landscape" || mode === "portrait") {
-                    widgetConfig.autoOrientation = false;
-                    widgetConfig.orientation = mode;//Overwrites default value
+                if (mode === "landscape" || mode === "portrait" || mode === "north") {
+                    widgetConfig.autoOrientation = false;//Overwrites default value
+                    widgetConfig.orientation = mode;
+                } else if (mode !== "auto") {
+                    //Mode invalid, throw error
+                    throw localize.translate("EXCEPTION_ORIENTATION_MODE", mode);
                 }
             }
         }

--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -27,24 +27,40 @@ var fs = require("fsext"),
     utils = require("./packager-utils"),
     i18nMgr = require("./i18n-manager"),
     _self,
-    _predefinedFeatures = {
-        "enable-flash" : function enableFlashFeature(feature, widgetConfig) {
-            widgetConfig.enableFlash = true;
-        },
-        "blackberry.app.orientation": function orientationFeature(feature, widgetConfig) {
-            if (feature) {
-                var mode = feature.mode;
+    _predefinedFeatures,
+    _hybridFeatures;
 
-                if (mode === "landscape" || mode === "portrait" || mode === "north") {
-                    widgetConfig.autoOrientation = false;//Overwrites default value
-                    widgetConfig.orientation = mode;
-                } else if (mode !== "auto") {
-                    //Mode invalid, throw error
-                    throw localize.translate("EXCEPTION_ORIENTATION_MODE", mode);
+//This function will convert a wc3 paramObj with a list of
+//<param name="" value=""> elements into a single object
+function processParamObj(paramObj) {
+    var processedObj = {},
+        attribs,
+        paramName,
+        paramValue;
+
+    if (paramObj) {
+        //Convert to array for single param entries where only an object is created
+        if (!Array.isArray(paramObj)) {
+            paramObj = [paramObj];
+        }
+
+        paramObj.forEach(function (param) {
+            attribs = param["@"];
+
+            if (attribs) {
+                paramName = attribs["name"];
+                paramValue = attribs["value"];
+
+                if (paramName && paramValue) {
+                    //Add the key/value pair to the processedObj
+                    processedObj[paramName] = paramValue;
                 }
             }
-        }
-    };
+        });
+    }
+
+    return processedObj;
+}
 
 function processFeatures(featuresArray, widgetConfig, extManager, processPredefinedFeatures) {
     var features = [],
@@ -56,12 +72,16 @@ function processFeatures(featuresArray, widgetConfig, extManager, processPredefi
             if (attribs) {
                 attribs.required = packagerUtils.toBoolean(attribs.required, true);
 
-                //Check for predefined features that do not have source code
                 if (_predefinedFeatures[attribs.id]) {
+                    //Handle features that do NOT contain an API namespace
                     if (processPredefinedFeatures) {
                         _predefinedFeatures[attribs.id](feature, widgetConfig);
                     }
                 } else {
+                    //Handle features that contain both a namespace and custom params
+                    if (_hybridFeatures[attribs.id]) {
+                        _hybridFeatures[attribs.id](feature, widgetConfig);
+                    }
                     features.push(attribs);
                 }
             } else {
@@ -492,11 +512,50 @@ function processResult(data, session, extManager) {
     return widgetConfig;
 }
 
+function init() {
+    //Predefined features are features that do NOT contain an API namespace
+    _predefinedFeatures = {
+        "enable-flash" : function (feature, widgetConfig) {
+            widgetConfig.enableFlash = true;
+        },
+        "blackberry.app.orientation": function (feature, widgetConfig) {
+            if (feature) {
+                var params = processParamObj(feature.param),
+                    mode = params.mode;
+
+                if (mode === "landscape" || mode === "portrait" || mode === "north") {
+                    widgetConfig.autoOrientation = false;//Overwrites default value
+                    widgetConfig.orientation = mode;
+                } else if (mode !== "auto") {
+                    //Mode invalid, throw error
+                    throw localize.translate("EXCEPTION_ORIENTATION_MODE", mode);
+                }
+            }
+        }
+    };
+
+    //Hybrid features are features that have both an API namespace and custom parameters
+    _hybridFeatures = {
+        "blackberry.app": function (feature, widgetConfig) {
+            if (feature) {
+                var params = processParamObj(feature.param),
+                    bgColor = params.backgroundColor;
+
+                if (bgColor) {
+                    widgetConfig.backgroundColor = bgColor;
+                }
+            }
+        }
+    };
+}
+
 _self = {
     parse: function (xmlPath, session, extManager, callback) {
         var fileData = fs.readFileSync(xmlPath),
             xml = utils.bufferToString(fileData),
             parser = new xml2js.Parser({trim: true, normalize: true, explicitRoot: false});
+
+        init();
 
         //parse xml file data
         parser.parseString(xml, function (err, result) {

--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -523,12 +523,15 @@ function init() {
                 var params = processParamObj(feature.param),
                     mode = params.mode;
 
-                if (mode === "landscape" || mode === "portrait" || mode === "north") {
+                if (!mode) {
+                    //No mode provided, throw error
+                    throw localize.translate("EXCEPTION_EMPTY_ORIENTATION_MODE", mode);
+                } else if (mode === "landscape" || mode === "portrait" || mode === "north") {
                     widgetConfig.autoOrientation = false;//Overwrites default value
                     widgetConfig.orientation = mode;
                 } else if (mode !== "auto") {
                     //Mode invalid, throw error
-                    throw localize.translate("EXCEPTION_ORIENTATION_MODE", mode);
+                    throw localize.translate("EXCEPTION_INVALID_ORIENTATION_MODE", mode);
                 }
             }
         }
@@ -542,12 +545,14 @@ function init() {
                     bgColor = params.backgroundColor;
 
                 if (bgColor) {
-                    try {
-                        //Convert bgColor to a number
-                        widgetConfig.backgroundColor = parseInt(bgColor, 16);
-                    } catch (err) {
+                    //Convert bgColor to a number
+                    bgColor = parseInt(bgColor, 16);
+
+                    if (isNaN(bgColor)) {
                         //bgcolor is not a number, throw error
-                        throw localize.translate("EXCEPTION_BGCOLOR_INVALID");
+                        throw localize.translate("EXCEPTION_BGCOLOR_INVALID", params.backgroundColor);
+                    } else {
+                        widgetConfig.backgroundColor = bgColor;
                     }
                 }
             }

--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -312,8 +312,8 @@ function processContentData(data, widgetConfig) {
 }
 
 function processOrientationData(data, widgetConfig) {
-    if (data["rim:orientation"]) {
-        var mode = data["rim:orientation"].mode;
+    if (data["rim:orientation"] && data["rim:orientation"]["@"]) {
+        var mode = data["rim:orientation"]["@"].mode;
 
         if (mode === "landscape" || mode === "portrait") {
             widgetConfig.autoOrientation = false;
@@ -321,7 +321,7 @@ function processOrientationData(data, widgetConfig) {
             return;
         }
     }
-
+    
     //Default value
     widgetConfig.autoOrientation = true;
 }

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -153,6 +153,9 @@ var Localize = require("localize"),
         },
         "EXCEPTION_ORIENTATION_MODE": {
             "en": "\"$[1]\" is not a valid orientation mode"
+        },
+        "EXCEPTION_BGCOLOR_INVALID" : {
+            "en": "Background color \"$[1]\" is not a valid number"
         }
 
     }, "", ""); // TODO maybe a bug in localize, must set default locale to "" in order get it to work

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -151,8 +151,11 @@ var Localize = require("localize"),
         "EXCEPTION_PARAMS_FILE_NOT_FOUND": {
             "en": "\"$[1]\" does not exist"
         },
-        "EXCEPTION_ORIENTATION_MODE": {
+        "EXCEPTION_INVALID_ORIENTATION_MODE": {
             "en": "\"$[1]\" is not a valid orientation mode"
+        },
+        "EXCEPTION_EMPTY_ORIENTATION_MODE": {
+            "en": "blackberry.app.orientation parameter \"mode\" missing"
         },
         "EXCEPTION_BGCOLOR_INVALID" : {
             "en": "Background color \"$[1]\" is not a valid number"

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -150,7 +150,11 @@ var Localize = require("localize"),
         },
         "EXCEPTION_PARAMS_FILE_NOT_FOUND": {
             "en": "\"$[1]\" does not exist"
+        },
+        "EXCEPTION_ORIENTATION_MODE": {
+            "en": "\"$[1]\" is not a valid orientation mode"
         }
+
     }, "", ""); // TODO maybe a bug in localize, must set default locale to "" in order get it to work
 
 loc.setLocale("en");

--- a/lib/native-packager.js
+++ b/lib/native-packager.js
@@ -134,6 +134,14 @@ function generateTabletXMLFile(session, config) {
     if (config.permissions) {
         xmlObject.action = config.permissions;
     }
+    
+    //Add orientation mode
+    if (config.orientation) {
+        xmlObject.initialWindow.aspectRatio = config.orientation;
+    }
+    
+    //Add auto orientation
+    xmlObject.initialWindow.autoOrients = config.autoOrientation;
 
     pkgrUtils.writeFile(session.sourceDir, "blackberry-tablet.xml", data2xml('qnx', xmlObject));
 }

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -935,7 +935,8 @@ describe("config parser", function () {
 
         it("sets orientation to landscape when specified", function () {
             var data = testUtilities.cloneObj(testData.xml2jsConfig);
-            data['feature'] = {'@': {id: 'blackberry.app.orientation'}, mode: "landscape"};
+            data['feature'] = { '@': { id: 'blackberry.app.orientation', required: true },
+                    param: { '@': { name: 'mode', value: 'landscape' } } };
 
             mockParsing(data);
 
@@ -947,7 +948,8 @@ describe("config parser", function () {
 
         it("sets orientation to portrait when specified", function () {
             var data = testUtilities.cloneObj(testData.xml2jsConfig);
-            data['feature'] = {'@': {id: 'blackberry.app.orientation'}, mode: "portrait"};
+            data['feature'] = { '@': { id: 'blackberry.app.orientation', required: true },
+                    param: { '@': { name: 'mode', value: 'portrait' } } };
 
             mockParsing(data);
 
@@ -965,6 +967,18 @@ describe("config parser", function () {
 
             configParser.parse(configPath, session, extManager, function (configObj) {
                 expect(configObj.autoOrientation).toEqual(true);
+            });
+        });
+
+        it("sets backgroundColor when specified via blackberry.app namespace", function () {
+            var data = testUtilities.cloneObj(testData.xml2jsConfig);
+            data['feature'] = { '@': { id: 'blackberry.app', required: true },
+                    param: { '@': { name: 'backgroundColor', value: '0xffffff' } } };
+
+            mockParsing(data);
+
+            configParser.parse(configPath, session, extManager, function (configObj) {
+                expect(configObj.backgroundColor).toEqual("0xffffff");
             });
         });
     });

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -978,7 +978,7 @@ describe("config parser", function () {
             mockParsing(data);
 
             configParser.parse(configPath, session, extManager, function (configObj) {
-                expect(configObj.backgroundColor).toEqual("0xffffff");
+                expect(configObj.backgroundColor).toEqual(16777215);//Decimal value of 0xffffff
             });
         });
     });

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -934,42 +934,38 @@ describe("config parser", function () {
         });
 
         it("sets orientation to landscape when specified", function () {
-        var data = testUtilities.cloneObj(testData.xml2jsConfig);
-        data["rim:orientation"] = {
-            "@": { mode: "landscape" }
-        };
-        
-        mockParsing(data);
-        
-        configParser.parse(configPath, session, function (configObj) {
-            expect(configObj.orientation).toEqual("landscape");
-            expect(configObj.autoOrientation).toEqual(false);
+            var data = testUtilities.cloneObj(testData.xml2jsConfig);
+            data['feature'] = {'@': {id: 'blackberry.app.orientation'}, mode: "landscape"};
+
+            mockParsing(data);
+
+            configParser.parse(configPath, session, extManager, function (configObj) {
+                expect(configObj.orientation).toEqual("landscape");
+                expect(configObj.autoOrientation).toEqual(false);
+            });
         });
-    });
-    
-    it("sets orientation to portrait when specified", function () {
-        var data = testUtilities.cloneObj(testData.xml2jsConfig);
-        data["rim:orientation"] = {
-            "@": { mode: "portrait" }
-        };
-        
-        mockParsing(data);
-        
-        configParser.parse(configPath, session, function (configObj) {
-            expect(configObj.orientation).toEqual("portrait");
-            expect(configObj.autoOrientation).toEqual(false);
+
+        it("sets orientation to portrait when specified", function () {
+            var data = testUtilities.cloneObj(testData.xml2jsConfig);
+            data['feature'] = {'@': {id: 'blackberry.app.orientation'}, mode: "portrait"};
+
+            mockParsing(data);
+
+            configParser.parse(configPath, session, extManager, function (configObj) {
+                expect(configObj.orientation).toEqual("portrait");
+                expect(configObj.autoOrientation).toEqual(false);
+            });
         });
-    });
-    
-    it("sets auto orientation to true by default", function () {
-        var data = testUtilities.cloneObj(testData.xml2jsConfig);
-        delete data["rim:orientation"];//Remove any orientation data
-        
-        mockParsing(data);
-        
-        configParser.parse(configPath, session, function (configObj) {
-            expect(configObj.autoOrientation).toEqual(true);
+
+        it("sets auto orientation to true by default", function () {
+            var data = testUtilities.cloneObj(testData.xml2jsConfig);
+            delete data["feature"];//Remove any orientation data
+
+            mockParsing(data);
+
+            configParser.parse(configPath, session, extManager, function (configObj) {
+                expect(configObj.autoOrientation).toEqual(true);
+            });
         });
-    });
     });
 });

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -932,5 +932,44 @@ describe("config parser", function () {
                 expect(configObj.icon).not.toContain("default-icon.png");
             });
         });
+
+        it("sets orientation to landscape when specified", function () {
+        var data = testUtilities.cloneObj(testData.xml2jsConfig);
+        data["rim:orientation"] = {
+            "@": { mode: "landscape" }
+        };
+        
+        mockParsing(data);
+        
+        configParser.parse(configPath, session, function (configObj) {
+            expect(configObj.orientation).toEqual("landscape");
+            expect(configObj.autoOrientation).toEqual(false);
+        });
+    });
+    
+    it("sets orientation to portrait when specified", function () {
+        var data = testUtilities.cloneObj(testData.xml2jsConfig);
+        data["rim:orientation"] = {
+            "@": { mode: "portrait" }
+        };
+        
+        mockParsing(data);
+        
+        configParser.parse(configPath, session, function (configObj) {
+            expect(configObj.orientation).toEqual("portrait");
+            expect(configObj.autoOrientation).toEqual(false);
+        });
+    });
+    
+    it("sets auto orientation to true by default", function () {
+        var data = testUtilities.cloneObj(testData.xml2jsConfig);
+        delete data["rim:orientation"];//Remove any orientation data
+        
+        mockParsing(data);
+        
+        configParser.parse(configPath, session, function (configObj) {
+            expect(configObj.autoOrientation).toEqual(true);
+        });
+    });
     });
 });

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -553,13 +553,13 @@ describe("config parser", function () {
             },
             "type": "application",
             "filter":  [{
-                    "action":  "bb.action.OPEN",
-                    "mime-type": ["text/*", "image/*"]
-                }, {
-                    "action": "bb.action.SET",
-                    "mime-type": "image/*"
-                }]
-            };
+                "action":  "bb.action.OPEN",
+                "mime-type": ["text/*", "image/*"]
+            }, {
+                "action": "bb.action.SET",
+                "mime-type": "image/*"
+            }]
+        };
 
         mockParsing(data);
 
@@ -571,16 +571,16 @@ describe("config parser", function () {
     it("can parse multiple invoke targets", function () {
         var data = testUtilities.cloneObj(testData.xml2jsConfig);
         data["rim:invoke-target"] = [{
-                "@": {
-                    "id": "com.domain.subdomain.appName.app"
-                },
-                "type": "application",
-            }, {
-                "@": {
-                    "id": "com.domain.subdomain.appName.viewer"
-                },
-                "type": "viewer"
-            }];
+            "@": {
+                "id": "com.domain.subdomain.appName.app"
+            },
+            "type": "application",
+        }, {
+            "@": {
+                "id": "com.domain.subdomain.appName.viewer"
+            },
+            "type": "viewer"
+        }];
 
         mockParsing(data);
 
@@ -729,12 +729,12 @@ describe("config parser", function () {
         it("throws error when one of many rim:splash elements does not contain attribute", function () {
             var data = testUtilities.cloneObj(testData.xml2jsConfig);
             data["rim:splash"] = [{
-                    "@": {
-                        "src": "a.jpg"
-                    }
-                }, {
-                    "#": "blah"
-                }];
+                "@": {
+                    "src": "a.jpg"
+                }
+            }, {
+                "#": "blah"
+            }];
 
             mockParsing(data);
 
@@ -761,14 +761,14 @@ describe("config parser", function () {
         it("allow multiple rim:splash elements that contain non-empty src attribute", function () {
             var data = testUtilities.cloneObj(testData.xml2jsConfig);
             data["rim:splash"] = [{
-                    "@": {
-                        "src": "a.jpg"
-                    }
-                }, {
-                    "@": {
-                        "src": "b.jpg"
-                    }
-                }];
+                "@": {
+                    "src": "a.jpg"
+                }
+            }, {
+                "@": {
+                    "src": "b.jpg"
+                }
+            }];
 
             mockParsing(data);
 
@@ -780,14 +780,14 @@ describe("config parser", function () {
         it("throws error when rim:splash src starts with 'locales' subfolder", function () {
             var data = testUtilities.cloneObj(testData.xml2jsConfig);
             data["rim:splash"] = [{
-                    "@": {
-                        "src": "a.jpg"
-                    }
-                }, {
-                    "@": {
-                        "src": "locales/en/b.jpg"
-                    }
-                }];
+                "@": {
+                    "src": "a.jpg"
+                }
+            }, {
+                "@": {
+                    "src": "locales/en/b.jpg"
+                }
+            }];
 
             mockParsing(data);
 
@@ -827,12 +827,12 @@ describe("config parser", function () {
         it("throws error when one of many icon elements does not contain attribute", function () {
             var data = testUtilities.cloneObj(testData.xml2jsConfig);
             data["icon"] = [{
-                    "@": {
-                        "src": "a.jpg"
-                    }
-                }, {
-                    "#": "blah"
-                }];
+                "@": {
+                    "src": "a.jpg"
+                }
+            }, {
+                "#": "blah"
+            }];
 
             mockParsing(data);
 
@@ -859,14 +859,14 @@ describe("config parser", function () {
         it("allow multiple icon elements that contain non-empty src attribute", function () {
             var data = testUtilities.cloneObj(testData.xml2jsConfig);
             data["icon"] = [{
-                    "@": {
-                        "src": "a.jpg"
-                    }
-                }, {
-                    "@": {
-                        "src": "b.jpg"
-                    }
-                }];
+                "@": {
+                    "src": "a.jpg"
+                }
+            }, {
+                "@": {
+                    "src": "b.jpg"
+                }
+            }];
 
             mockParsing(data);
 
@@ -878,14 +878,14 @@ describe("config parser", function () {
         it("throws error when icon src starts with 'locales' subfolder", function () {
             var data = testUtilities.cloneObj(testData.xml2jsConfig);
             data["icon"] = [{
-                    "@": {
-                        "src": "a.jpg"
-                    }
-                }, {
-                    "@": {
-                        "src": "locales/en/b.jpg"
-                    }
-                }];
+                "@": {
+                    "src": "a.jpg"
+                }
+            }, {
+                "@": {
+                    "src": "locales/en/b.jpg"
+                }
+            }];
 
             mockParsing(data);
 
@@ -936,7 +936,7 @@ describe("config parser", function () {
         it("sets orientation to landscape when specified", function () {
             var data = testUtilities.cloneObj(testData.xml2jsConfig);
             data['feature'] = { '@': { id: 'blackberry.app.orientation', required: true },
-                    param: { '@': { name: 'mode', value: 'landscape' } } };
+                param: { '@': { name: 'mode', value: 'landscape' } } };
 
             mockParsing(data);
 
@@ -949,7 +949,7 @@ describe("config parser", function () {
         it("sets orientation to portrait when specified", function () {
             var data = testUtilities.cloneObj(testData.xml2jsConfig);
             data['feature'] = { '@': { id: 'blackberry.app.orientation', required: true },
-                    param: { '@': { name: 'mode', value: 'portrait' } } };
+                param: { '@': { name: 'mode', value: 'portrait' } } };
 
             mockParsing(data);
 
@@ -970,16 +970,54 @@ describe("config parser", function () {
             });
         });
 
+        it("throws an error when blackberry.app.orientation exists with no mode param", function () {
+            var data = testUtilities.cloneObj(testData.xml2jsConfig);
+            data['feature'] = { '@': { id: 'blackberry.app.orientation', required: true }};
+
+            mockParsing(data);
+
+            //Should throw an EXCEPTION_EMPTY_ORIENTATION_MODE error
+            expect(function () {
+                configParser.parse(configPath, session, extManager, {});
+            }).toThrow(localize.translate("EXCEPTION_EMPTY_ORIENTATION_MODE"));
+        });
+
+        it("throws an error when blackberry.app.orientation exists with an invalid mode param", function () {
+            var data = testUtilities.cloneObj(testData.xml2jsConfig);
+            data['feature'] = { '@': { id: 'blackberry.app.orientation', required: true },
+                param: { '@': { name: 'mode', value: 'notAValidMode' } } };
+
+            mockParsing(data);
+
+            //Should throw an EXCEPTION_INVALID_ORIENTATION_MODE error
+            expect(function () {
+                configParser.parse(configPath, session, extManager, {});
+            }).toThrow(localize.translate("EXCEPTION_INVALID_ORIENTATION_MODE", "notAValidMode"));
+        });
+
         it("sets backgroundColor when specified via blackberry.app namespace", function () {
             var data = testUtilities.cloneObj(testData.xml2jsConfig);
             data['feature'] = { '@': { id: 'blackberry.app', required: true },
-                    param: { '@': { name: 'backgroundColor', value: '0xffffff' } } };
+                param: { '@': { name: 'backgroundColor', value: '0xffffff' } } };
 
             mockParsing(data);
 
             configParser.parse(configPath, session, extManager, function (configObj) {
                 expect(configObj.backgroundColor).toEqual(16777215);//Decimal value of 0xffffff
             });
+        });
+
+        it("throws an error when blackberry.app backgroundColor param is not a number", function () {
+            var data = testUtilities.cloneObj(testData.xml2jsConfig);
+            data['feature'] = { '@': { id: 'blackberry.app', required: true },
+                param: { '@': { name: 'backgroundColor', value: '$UI*@@$' } } };
+
+            mockParsing(data);
+
+            //Should throw an EXCEPTION_BGCOLOR_INVALID error
+            expect(function () {
+                configParser.parse(configPath, session, extManager, {});
+            }).toThrow(localize.translate("EXCEPTION_BGCOLOR_INVALID", "$UI*@@$"));
         });
     });
 });

--- a/test/unit/lib/test-data.js
+++ b/test/unit/lib/test-data.js
@@ -36,7 +36,8 @@ module.exports = {
         "version": '1.0.0',
         "author": 'Research In Motion Ltd.',
         "description": 'This is a test!',
-        "image": 'test.png'
+        "image": 'test.png',
+        "autoOrientation": true
     },
     accessList: [{
         uri: "http://google.com",


### PR DESCRIPTION
Fixes issue blackberry/BB10-WebWorks-Framework#88
Fixes issue blackberry/BB10-WebWorks-Packager#108

FYI, it appears as though "north" is not supported in the native-packager yet.
I have added support for north on our side, but until native-packager supports it, the user will get a native-packager exception when packaging.

`[INFO] [ERROR] MANIFEST.MF: Invalid value 'north' for attribute 'Entry-Point-Orientation'.
[ERROR] Native Packager exception occurred`
