### PR TITLE
Changes the packager to accept the folder location instead of zip and

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -2,3 +2,4 @@
 node_modules
 target
 Framework
+third_party/

--- a/build/test.js
+++ b/build/test.js
@@ -17,7 +17,7 @@ module.exports = function (done, custom) {
     var jasmine = require('jasmine-node'),
         verbose = false,
         colored = false,
-        specs = __dirname + "/../" + (custom ? custom : "test"),
+        specs = __dirname + "/../" + (custom ? custom : "test/unit"),
         key;
 
     //HACK: this should be  taken out if our pull request in jasmine is accepted.

--- a/lib/bbwp.js
+++ b/lib/bbwp.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+require('./../third_party/wrench/wrench');
+
 var path = require("path"),
     wrench = require("wrench"),
     cmdline = require("./cmdline"),
@@ -31,7 +33,7 @@ try {
     cmdline.parse(process.argv);
     session = require("./session").initialize(cmdline.commander);
     extManager = require("./extension-manager").initialize(session);
-    
+
     //prepare files for webworks archiving
     logger.info(localize.translate("PROGRESS_FILE_POPULATING_SOURCE"));
     fileManager.prepareOutputFiles(session);
@@ -41,9 +43,9 @@ try {
     configParser.parse(path.join(session.sourceDir, "config.xml"), session, extManager, function (configObj) {
         //validate session Object
         packagerValidator.validateSession(session, configObj);
-        //validage configuration object        
+        //validage configuration object
         packagerValidator.validateConfig(session, configObj, extManager);
-        
+
         //generate user.js
         logger.info(localize.translate("PROGRESS_GEN_OUTPUT"));
         //Adding debuEnabled property to user.js. Framework will enable/disable WebInspector based on that variable.
@@ -64,6 +66,6 @@ try {
     try {
         fileManager.cleanSource(session);
     } catch (e) {}
-    
+
     logger.error(e);
 }

--- a/lib/bbwpignore.js
+++ b/lib/bbwpignore.js
@@ -1,0 +1,129 @@
+/*
+ *  Copyright 2012 Research In Motion Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require("fs"),
+    path = require("path"),
+    BBWPignore;
+
+function getDirectory(file) {
+    if (file.match("/$")) {
+        return file;
+    } else if (file.indexOf("/") === -1) {
+        return "";
+    } else {
+        return file.substring(0, file.lastIndexOf("/"));
+    }
+}
+
+function trim(str) {
+    return str.replace(/^\s+|\s+$/g, "");
+}
+
+BBWPignore = function (bbwpIgnoreFile, filesToMatch) {
+    var comments = [],
+        directories = [],
+        wildcardEntries = [],
+        files = [],
+        split,
+        matched = [],
+        i,
+        temparr,
+        tempFiles = [];
+    temparr = fs.readFileSync(bbwpIgnoreFile, "utf-8").split('\n');
+
+    //switch all the paths to relative, so if someone has passed absolute paths convert them to relative to .bbwpignore
+    filesToMatch.forEach(function (file) {
+        if (file === path.resolve(file)) { //if path is absolute
+            tempFiles.push(path.relative(path.dirname(bbwpIgnoreFile), file));
+        } else {
+            tempFiles.push(file);
+        }
+    });
+    filesToMatch = tempFiles;
+
+    //run through all the patterns in the bbwpignore and put them in appropriate arrays
+    for (i = 0; i < temparr.length; i++) {
+        temparr[i] = trim(temparr[i]);
+        if (temparr[i] !== "") {
+            if (temparr[i].match("^#")) {
+                comments.push(temparr[i]);
+            } else if (temparr[i].match("^/") && temparr[i].match("/$")) {
+                directories.push(temparr[i]);
+            } else if (temparr[i].indexOf("*") !== -1) {
+                split = temparr[i].split("/");
+                if (split[split.length - 1].indexOf("*") !== -1) { // only wildcards in the file name are supported, not in directory names
+                    wildcardEntries.push(temparr[i]);
+                } else {
+                    files.push(temparr[i]);
+                }
+            } else {
+                files.push(temparr[i]);
+            }
+        }
+    }
+
+    //run through all the files and check it against each of the patterns collected earlier
+    filesToMatch.forEach(function (fileToMatch) {
+        var directory,
+            dirOrig = getDirectory(fileToMatch),
+            isMatch = false;
+        //match directories
+        directory = "/" + dirOrig + "/";
+        if (directories.indexOf(directory) !== -1) {
+            matched.push(fileToMatch);
+            //add the directory to the list as well but only check
+            if (matched.indexOf("/" + dirOrig) === -1) {
+                matched.push("/" + dirOrig);
+            }
+            isMatch = true;
+        } else {
+            //handle special case when match patterns begin with /
+            //match wildCards
+            wildcardEntries.forEach(function (wildcard) {
+                if (wildcard.match("^/")) { // special case looking for exact match
+                    wildcard = "^" + wildcard.replace("*", "[^\/]*");
+                    if (("/" + fileToMatch).match(wildcard)) {
+                        matched.push(fileToMatch);
+                        isMatch = true;
+                    }
+                } else {
+                    wildcard = wildcard.replace("*", "[^\/]*");
+                    if (fileToMatch.match(wildcard)) {
+                        matched.push(fileToMatch);
+                        isMatch = true;
+                    }
+                }
+            });
+            if (!isMatch) { //must be a file
+                files.forEach(function (file) {
+                    if (file.match("^/")) { // special case looking for exact match
+                        if (file === ("/" + fileToMatch)) {
+                            matched.push(fileToMatch);
+                            isMatch = true;
+                        }
+                    } else if (fileToMatch.match(file)) {
+                        matched.push(fileToMatch);
+                        isMatch = true;
+                    }
+                });
+
+            }
+        }
+    });
+    this.matchedFiles = matched;
+};
+
+module.exports = BBWPignore;

--- a/lib/conf.js
+++ b/lib/conf.js
@@ -29,5 +29,6 @@ module.exports = {
     DEPENDENCIES_WWE: path.normalize(__dirname + "/../dependencies/%s-wwe"),
     DEBUG_TOKEN: path.normalize(__dirname + "/../debugtoken.bar"),
     DEFAULT_ICON: path.normalize(__dirname + "/../default-icon.png"),
-    BAR_DESCRIPTOR: "bar-descriptor.xml"
+    BAR_DESCRIPTOR: "bar-descriptor.xml",
+    BBWP_IGNORE_FILENAME: ".bbwpignore"
 };

--- a/lib/file-manager.js
+++ b/lib/file-manager.js
@@ -18,6 +18,8 @@ var path = require("path"),
     util = require("util"),
     packager_utils = require("./packager-utils"),
     fs = require("fsext"),
+    conf = require("./conf"),
+    BBWPignore = require('./bbwpignore'),
     wrench = require("wrench"),
     zip = require("zip"),
     localize = require("./localize"),
@@ -55,6 +57,25 @@ function unzip(from, to) {
     }
 }
 
+function copyDirContents(from, to) {
+    var files = wrench.readdirSyncRecursive(from),
+        bbwpignore,
+        bbwpignoreFile = path.join(from, conf.BBWP_IGNORE_FILENAME),
+        toBeIgnored = [];
+
+    if (path.existsSync(bbwpignoreFile)) {
+        bbwpignore = new BBWPignore(bbwpignoreFile, files);
+
+        bbwpignore.matchedFiles.forEach(function (i) {
+            toBeIgnored.push(from + "/" + i);
+        });
+        toBeIgnored.push(from + "/" + conf.BBWP_IGNORE_FILENAME); //add the .bbwpignore file to the ignore list
+    }
+    wrench.copyDirSyncRecursive(from, to, {preserve: true}, function (file) {
+        return toBeIgnored.indexOf(file) === -1;
+    });
+}
+
 function prepare(session) {
     var conf = session.conf,
         dest = session.sourcePaths,
@@ -80,7 +101,11 @@ function prepare(session) {
     wrench.copyDirSyncRecursive(conf.UI, dest.UI);
 
     // unzip archive
-    unzip(session.archivePath, session.sourceDir);
+    if (session.archivePath.toLowerCase().match("[.]zip$")) {
+        unzip(session.archivePath, session.sourceDir);
+    } else {
+        copyDirContents(session.archivePath, session.sourceDir);
+    }
 
     //test for existing webworks.js files
     webworksJsFiles = packager_utils.listFiles(session.sourceDir, function (file) {
@@ -89,7 +114,6 @@ function prepare(session) {
     if (webworksJsFiles.length > 0) {
         logger.warn(localize.translate("WARN_WEBWORKS_JS_PACKAGED"));
     }
-
 }
 
 
@@ -300,5 +324,7 @@ module.exports = {
         if (!session.keepSource) {
             wrench.rmdirSyncRecursive(session.sourceDir);
         }
-    }
+    },
+
+    copyDirContents: copyDirContents
 };

--- a/test/unit/lib/bbwpignore.js
+++ b/test/unit/lib/bbwpignore.js
@@ -1,0 +1,135 @@
+/*
+ *  Copyright 2012 Research In Motion Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var srcPath = __dirname + "/../../../lib/",
+    BBWPignore = require(srcPath + "bbwpignore"),
+    fs = require('fs');
+
+describe("bbwpignore can match", function () {
+    it("a basic file set", function () {
+        var bbwpignore;
+        spyOn(fs, "readFileSync").andReturn("abc.js\n" +
+                                           "x/y/def.js");
+        bbwpignore = new BBWPignore("FileNameIgnoreForTests",
+                                    ["d/e/abc.js", "abc.js", "ted.js", ".DS_Store",
+                                        "x/y/def.js", "x/def.js", "a/b/x/y/def.js"]);
+        expect(bbwpignore.matchedFiles.length).toBe(4);
+        expect(bbwpignore.matchedFiles.indexOf("d/e/abc.js")).not.toBe(-1);
+        expect(bbwpignore.matchedFiles.indexOf("abc.js")).not.toBe(-1);
+        expect(bbwpignore.matchedFiles.indexOf("x/y/def.js")).not.toBe(-1);
+        expect(bbwpignore.matchedFiles.indexOf("a/b/x/y/def.js")).not.toBe(-1);
+    });
+
+    it("a basic file set with directories", function () {
+        var bbwpignore;
+        spyOn(fs, "readFileSync").andReturn("abc.js\n" +
+                                           "x/y/");
+        bbwpignore = new BBWPignore("FileNameIgnoreForTests",
+                                    ["d/e/abc.js", "abc.js", "ted.js", ".DS_Store",
+                                        "x/y/def.js", "x/def.js", "a/b/x/y/def.js"]);
+
+        expect(bbwpignore.matchedFiles.length).toBe(4);
+        expect(bbwpignore.matchedFiles.indexOf("d/e/abc.js")).not.toBe(-1);
+        expect(bbwpignore.matchedFiles.indexOf("abc.js")).not.toBe(-1);
+        expect(bbwpignore.matchedFiles.indexOf("x/y/def.js")).not.toBe(-1);
+        expect(bbwpignore.matchedFiles.indexOf("a/b/x/y/def.js")).not.toBe(-1);
+    });
+
+    it("a basic file set with directories that being with slash", function () {
+        var bbwpignore;
+        spyOn(fs, "readFileSync").andReturn("abc.js\n" +
+                                           "/x/y/");
+        bbwpignore = new BBWPignore("FileNameIgnoreForTests",
+                                    ["d/e/abc.js", "abc.js", "ted.js", ".DS_Store",
+                                        "x/y/def.js", "x/def.js", "a/b/x/y/def.js"]);
+        expect(bbwpignore.matchedFiles.length).toBe(4);
+        expect(bbwpignore.matchedFiles.indexOf("d/e/abc.js")).not.toBe(-1);
+        expect(bbwpignore.matchedFiles.indexOf("abc.js")).not.toBe(-1);
+        expect(bbwpignore.matchedFiles.indexOf("/x/y")).not.toBe(-1);
+        expect(bbwpignore.matchedFiles.indexOf("x/y/def.js")).not.toBe(-1);
+
+    });
+
+    it("a basic file set that begin with a slash on the directory", function () {
+        var bbwpignore;
+        spyOn(fs, "readFileSync").andReturn("abc.js\n" +
+                                           "/x/y/def.js");
+        bbwpignore = new BBWPignore("FileNameIgnoreForTests",
+                                    ["d/e/abc.js", "abc.js", "ted.js", ".DS_Store",
+                                        "x/y/def.js", "x/def.js", "a/b/x/y/def.js"]);
+
+        expect(bbwpignore.matchedFiles.length).toBe(3);
+        expect(bbwpignore.matchedFiles.indexOf("d/e/abc.js")).not.toBe(-1);
+        expect(bbwpignore.matchedFiles.indexOf("abc.js")).not.toBe(-1);
+        expect(bbwpignore.matchedFiles.indexOf("x/y/def.js")).not.toBe(-1);
+
+    });
+
+    it("a basic file set that begin with a slash", function () {
+        var bbwpignore;
+        spyOn(fs, "readFileSync").andReturn("abc.js\n" +
+                                           "/def.js");
+        bbwpignore = new BBWPignore("FileNameIgnoreForTests",
+                                    ["d/e/abc.js", "abc.js", "ted.js", ".DS_Store",
+                                        "x/y/def.js", "x/def.js", "a/b/x/y/def.js"]);
+
+        expect(bbwpignore.matchedFiles.length).toBe(2);
+        expect(bbwpignore.matchedFiles.indexOf("d/e/abc.js")).not.toBe(-1);
+        expect(bbwpignore.matchedFiles.indexOf("abc.js")).not.toBe(-1);
+
+    });
+
+    it("a basic file set that begin with a slash and has a wildcard", function () {
+        var bbwpignore;
+        spyOn(fs, "readFileSync").andReturn("abcd.js\n" +
+                                           "/*.js");
+        bbwpignore = new BBWPignore("FileNameIgnoreForTests",
+                                    ["d/e/abc.js", "abc.js", "ted.js", ".DS_Store",
+                                        "x/y/def.js", "x/def.js", "a/b/x/y/def.js"]);
+
+        expect(bbwpignore.matchedFiles.length).toBe(2);
+        expect(bbwpignore.matchedFiles.indexOf("abc.js")).not.toBe(-1);
+        expect(bbwpignore.matchedFiles.indexOf("ted.js")).not.toBe(-1);
+
+    });
+
+    it("a basic file set that begin with a slash and has a wildcard", function () {
+        var bbwpignore;
+        spyOn(fs, "readFileSync").andReturn("abcd.js\n" +
+                                           "a*.js");
+        bbwpignore = new BBWPignore("FileNameIgnoreForTests",
+                                    ["d/e/abc.js", "abc.js", "ted.js", ".DS_Store",
+                                        "x/y/def.js", "x/def.js", "a/b/x/y/def.js"]);
+
+        expect(bbwpignore.matchedFiles.length).toBe(2);
+        expect(bbwpignore.matchedFiles.indexOf("d/e/abc.js")).not.toBe(-1);
+        expect(bbwpignore.matchedFiles.indexOf("abc.js")).not.toBe(-1);
+
+    });
+
+    it("a basic directory set that begin with a slash", function () {
+        var bbwpignore;
+        spyOn(fs, "readFileSync").andReturn("/simulator/\n" +
+                                           "banana.js");
+        bbwpignore = new BBWPignore("FileNameIgnoreForTests",
+                                    ["simulator/a.js"]);
+
+        expect(bbwpignore.matchedFiles.length).toBe(2);
+        expect(bbwpignore.matchedFiles.indexOf("/simulator")).not.toBe(-1);
+        expect(bbwpignore.matchedFiles.indexOf("simulator/a.js")).not.toBe(-1);
+
+    });
+});

--- a/test/unit/lib/file-manager.js
+++ b/test/unit/lib/file-manager.js
@@ -7,6 +7,7 @@ var srcPath = __dirname + "/../../../lib/",
     localize = require(srcPath + "localize"),
     wrench = require("wrench"),
     logger = require(srcPath + "logger"),
+    conf = require(srcPath + "conf"),
     fileMgr = require(srcPath + "file-manager"),
     testData = require("./test-data"),
     session = testData.session,
@@ -29,6 +30,7 @@ describe("File manager", function () {
         expect(wrench.copyDirSyncRecursive).toHaveBeenCalledWith(session.conf.UI, session.sourcePaths.UI);
         expect(path.existsSync(session.sourcePaths.LIB)).toBeTruthy();
     });
+
 
     it("copyWWE() should copy wwe of the specified target", function () {
         spyOn(fs, "copySync");
@@ -231,6 +233,28 @@ describe("File manager", function () {
         expect(fs.statSync(session.sourceDir).isDirectory()).toBeTruthy();
         fileMgr.cleanSource(session);
         expect(path.existsSync(session.sourceDir)).toBeFalsy();
+    });
+
+    it("prepareOutputFiles() should copy files if a folder is sent in", function () {
+        spyOn(wrench, "copyDirSyncRecursive");
+        fileMgr.prepareOutputFiles(session);
+
+        expect(path.existsSync(session.sourcePaths.CHROME)).toBeTruthy();
+        expect(wrench.copyDirSyncRecursive).toHaveBeenCalledWith(session.conf.UI, session.sourcePaths.UI);
+        expect(path.existsSync(session.sourcePaths.LIB)).toBeTruthy();
+    });
+
+    it("prepareOutputFiles() should copy files if a folder is sent in without .bbwpignore", function () {
+        var oldPathExistsSync = path.existsSync;
+        spyOn(path, "existsSync").andCallFake(function (ipath) {
+            return path.basename(ipath) === conf.BBWP_IGNORE_FILENAME ? false : oldPathExistsSync(ipath);
+        });
+        spyOn(wrench, "copyDirSyncRecursive");
+        fileMgr.prepareOutputFiles(session);
+
+        expect(path.existsSync(session.sourcePaths.CHROME)).toBeTruthy();
+        expect(wrench.copyDirSyncRecursive).toHaveBeenCalledWith(session.conf.UI, session.sourcePaths.UI);
+        expect(path.existsSync(session.sourcePaths.LIB)).toBeTruthy();
     });
 
 });

--- a/third_party/wrench/wrench.js
+++ b/third_party/wrench/wrench.js
@@ -1,0 +1,78 @@
+/*  wrench.js
+ *
+ *  A collection of various utility functions I've found myself in need of
+ *  for use with Node.js (http://nodejs.org/). This includes things like:
+ *
+ *  - Recursively deleting directories in Node.js (Sync, not Async)
+ *  - Recursively copying directories in Node.js (Sync, not Async)
+ *  - Recursively chmoding a directory structure from Node.js (Sync, not Async)
+ *  - Other things that I'll add here as time goes on. Shhhh...
+ *
+ *  ~ Ryan McGrath (ryan [at] venodesigns.net)
+ */
+
+/* This file is originally licensed under https://raw.github.com/ryanmcgrath/wrench-js/master/LICENSE
+ * This code has been copied from https://raw.github.com/ryanmcgrath/wrench-js and modified
+ * add the functionality for a callback to the copyDirSyncRecursive method.
+ * Modifications have been clearly marked.
+ * The callback acts like a filter and you must return true/false from it to include/exclude a file
+ */
+
+var wrench = require('wrench'),
+    fs = require("fs"),
+    _path = require("path");
+/*  wrench.copyDirSyncRecursive("directory_to_copy", "new_directory_location", opts);
+ *
+ *  Recursively dives through a directory and moves all its files to a new location. This is a
+ *  Synchronous function, which blocks things until it's done. If you need/want to do this in
+ *  an Asynchronous manner, look at wrench.copyDirRecursively() below.
+ *
+ *  Note: Directories should be passed to this function without a trailing slash.
+ */
+wrench.copyDirSyncRecursive = function(sourceDir, newDirLocation, opts, callback) {
+
+    /**************************Modification*****************************************/
+    if (typeof opts === "function") {
+        callback = opts;
+        opts = {};
+    }
+    /**************************Modification End*****************************************/
+
+    if (!opts || !opts.preserve) {
+        try {
+            if(fs.statSync(newDirLocation).isDirectory()) wrench.rmdirSyncRecursive(newDirLocation);
+        } catch(e) { }
+    }
+
+    /*  Create the directory where all our junk is moving to; read the mode of the source directory and mirror it */
+    var checkDir = fs.statSync(sourceDir);
+    try {
+        fs.mkdirSync(newDirLocation, checkDir.mode);
+    } catch (e) {
+        //if the directory already exists, that's okay
+        if (e.code !== 'EEXIST') throw e;
+    }
+
+    var files = fs.readdirSync(sourceDir);
+
+    for(var i = 0; i < files.length; i++) {
+        var currFile = fs.lstatSync(sourceDir + "/" + files[i]);
+        /**************************Modified to add if statement*****************************************/
+        if (callback && !callback(sourceDir + "/" + files[i], currFile)) {
+            continue;
+        }
+        if(currFile.isDirectory()) {
+            /*  recursion this thing right on back. */
+            wrench.copyDirSyncRecursive(sourceDir + "/" + files[i], newDirLocation + "/" + files[i], opts, callback);
+        } else if(currFile.isSymbolicLink()) {
+            var symlinkFull = fs.readlinkSync(sourceDir + "/" + files[i]);
+            fs.symlinkSync(symlinkFull, newDirLocation + "/" + files[i]);
+        } else {
+            /*  At this point, we've hit a file actually worth copying... so copy it on over. */
+            var contents = fs.readFileSync(sourceDir + "/" + files[i]);
+            fs.writeFileSync(newDirLocation + "/" + files[i], contents);
+        }
+    }
+};
+
+


### PR DESCRIPTION
introduces .bbwpignore.

It introduces the concept of .bbwpignore to make sure that all the files
are filtered and not bundled with the app.

The spec for .bbwpignore follows that of .gitignore without support for
negations of patterns.
Key points from the spec are -

```
1. A leading slash matches the beginning of the pathname. For example,
"/*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c".
2. If the pattern does not contain a slash /, it will be treated as a
global pattern and *.c will match all files in root and subdirectories.
3. Directories must end with /
4. A line starting with # serves as a comment.
5. Blank lines are ignored.
6. ! which negates the pattern is NOT SUPPORTED
 A full spec for .gitignore can be found here -
http://www.kernel.org/pub/software/scm/git/docs/gitignore.html
```

Wrench has been modified to allow for a filter in the
copyDirSyncRecursive method to allow filtering on files.
Wrench code has been copied from -
https://github.com/ryanmcgrath/wrench-js
and then modified and placed in third_party/wrench folder where all
modifications are clearly marked.

Windows: If you use quotes in your path you provide on windows it must not end with a / because
it causes node to process the to think it is escaping the end " instead
of thinking it as the end of the string.
Take away is that you should use
bbwp "x/y/z" and not bbwp "x/y/z/"
This might get fixed in future version of node.js. Currently tested
against 0.6.10.

example .bbwpignore files will look like this

```
/*.zip
*.c
/device/
#/simulator/
```

Above will ignore all zip files in root
will ignore all .c files in root and subdirectories
will ignore the device folder
will comment out the simulator line and not do anything
