### PR TITLE
Added the dummy buildId if not specified

### DIFF
--- a/lib/native-packager.js
+++ b/lib/native-packager.js
@@ -133,6 +133,8 @@ function generateTabletXMLFile(session, config) {
     //buildId
     if (config.buildId) {
         xmlObject.buildId = config.buildId;
+    } else {
+        xmlObject.buildId = 1; // Add the dummy buildId if not specified
     }
 
     if (files) {

--- a/test/unit/lib/native-packager.js
+++ b/test/unit/lib/native-packager.js
@@ -127,6 +127,7 @@ describe("Native packager", function () {
             "<env value=\"8\" var=\"WEBKIT_NUMBER_OF_BACKINGSTORE_TILES\"></env>" +
             "<permission system=\"true\">run_native</permission>" +
             "<permission system=\"false\">access_internet</permission>" +
+            "<buildId>1</buildId>" +
             "<description>" + config.description + "</description></qnx>",
             cmd = path.normalize(session.conf.DEPENDENCIES_TOOLS + "/bin/blackberry-nativepackager" + (pkgrUtils.isWindows() ? ".bat" : ""));
 
@@ -145,6 +146,17 @@ describe("Native packager", function () {
 
         spyOn(pkgrUtils, "writeFile").andCallFake(function (fileLocation, fileName, fileData) {
             expect(fileData).toContain("<permission>read_device_identifying_information</permission>");
+        });
+
+        nativePkgr.exec(session, target, config, callback);
+
+    });
+
+    it("can generate buildId if not specified", function () {
+        var config = testUtils.cloneObj(testData.config);
+
+        spyOn(pkgrUtils, "writeFile").andCallFake(function (fileLocation, fileName, fileData) {
+            expect(fileData).toContain("<buildId>1</buildId>");
         });
 
         nativePkgr.exec(session, target, config, callback);


### PR DESCRIPTION
buildId is required in bar descriptor to pass build and release:
we should always generate it even the user doesn't specify it.

Fixes https://github.com/blackberry/BB10-Webworks-Packager/issues/211
