### PR TITLE
Added implementation to support specifying the bar descriptor path in command line

### DIFF
--- a/lib/cmdline.js
+++ b/lib/cmdline.js
@@ -28,6 +28,7 @@ command
     .option('-o, --output <dir>', 'Redirects output file location to dir. If both -o and dir are not specified then the path of archive is assumed')
     .option('-d, --debug', 'Allows use of not signed build on device by utilizing debug token and enables Web Inspector.')
     .option('-p, --params <params JSON file>', 'Specifies additional parameters to pass to downstream tools.')
+    .option('--appdesc <filepath>', 'Optionally specifies the path to the bar descriptor file (bar-descriptor.xml). For internal use only.')
     .option('-v, --verbose', 'Turn on verbose messages');
 
 function parseArgs(args) {

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -178,6 +178,9 @@ var Localize = require("localize"),
         "EXCEPTION_INVALID_ARCHIVE_PATH" : {
             "en": "An archive or directory does not exist at the path specified: \"$[1]\""
         },
+        "EXCEPTION_APPDESC_NOT_FOUND" : {
+            "en": "The bar descriptor file does not exist at the path specified: \"$[1]\""
+        },
         "WARNING_ORIENTATION_DEPRECATED": {
             "en": "blackberry.app.orientation has been deprecated, please use blackberry.app instead"
         }

--- a/lib/native-packager.js
+++ b/lib/native-packager.js
@@ -59,6 +59,12 @@ function generateTabletXMLFile(session, config) {
             }]
         };
 
+    // If appdesc is specified, use it as the bar descriptor
+    if (session.appdesc) {
+        fs.copySync(session.appdesc, path.join(session.sourceDir, conf.BAR_DESCRIPTOR));
+        return;
+    }
+
     //If version can be attained, set env variable
     if (webworksInfo && webworksInfo.version) {
         xmlObject.env.push({

--- a/lib/packager-validator.js
+++ b/lib/packager-validator.js
@@ -82,6 +82,11 @@ _self = {
             //if a buildId was provided in config.xml with NO password, throw warning
             logger.warn(localize.translate("WARNING_SIGNING_PASSWORD_EXPECTED"));
         }
+
+        //if --appdesc was provided, but the file is not existing, throw an error
+        if (session.appdesc && !path.existsSync(session.appdesc)) {
+            throw localize.translate("EXCEPTION_APPDESC_NOT_FOUND", session.appdesc);
+        }
     },
 
     //Validation for configObj, iterates through whitelisted features in configObj to remove any non-existing APIs

--- a/lib/session.js
+++ b/lib/session.js
@@ -54,6 +54,7 @@ module.exports = {
             outputDir = cmdline.output,
             archivePath = path.resolve(cmdline.args[0]),
             archiveName = path.basename(archivePath, '.zip'),
+            appdesc,
             buildId = cmdline.buildId;
 
         //If -o option was not provided, default output location is the same as .zip
@@ -63,7 +64,11 @@ module.exports = {
         if (cmdline.password && "string" === typeof cmdline.password) {
             signingPassword = cmdline.password;
         }
-        
+
+        if (cmdline.appdesc && "string" === typeof cmdline.appdesc) {
+            appdesc = path.resolve(cmdline.appdesc);
+        }
+
         //If -s [dir] is provided
         if (cmdline.source && "string" === typeof cmdline.source) {
             sourceDir = cmdline.source + "/src";
@@ -99,6 +104,7 @@ module.exports = {
             "keystoreDb": signingHelper.getDbPath(),
             "storepass": signingPassword,
             "buildId": buildId,
+            "appdesc" : appdesc,
             getParams: function (toolName) {
                 return getParams(cmdline, toolName);
             },

--- a/test/unit/lib/cmdline.js
+++ b/test/unit/lib/cmdline.js
@@ -58,6 +58,11 @@ describe("Command line", function () {
         expect(cmd.buildId).toEqual("100");
     });
 
+    it("accepts --appdesc with argument", function () {
+        cmd.parseOptions(["--appdesc", "bardescriptor"]);
+        expect(cmd.appdesc).toEqual("bardescriptor");
+    });
+
     it("throws an error for invalid multi-word arguments", function () {
         expect(function () {
             require(srcPath + "cmdline").parse(["--src"]);

--- a/test/unit/lib/packager-validator.js
+++ b/test/unit/lib/packager-validator.js
@@ -152,6 +152,20 @@ describe("Packager Validator", function () {
         expect(logger.warn).toHaveBeenCalledWith(localize.translate("WARNING_MISSING_SIGNING_KEY_FILE", "barsigner.db"));
     });
     
+    it("throws an exception when appdesc was not found", function () {
+        var session = testUtilities.cloneObj(testData.session),
+            configObj = testUtilities.cloneObj(testData.config);
+
+        //setup appdesc which is not existing
+        session.buildId = undefined;
+        configObj.buildId = undefined;
+        session.appdesc = "c:/bardescriptor.xml";
+
+        expect(function () {
+            packagerValidator.validateSession(session, configObj);
+        }).toThrow(localize.translate("EXCEPTION_APPDESC_NOT_FOUND", "c:/bardescriptor.xml"));
+    });
+    
     it("throws an exception when a password [-g] was set with no buildId", function () {
         var session = testUtilities.cloneObj(testData.session),
             configObj = testUtilities.cloneObj(testData.config);

--- a/test/unit/lib/session.js
+++ b/test/unit/lib/session.js
@@ -85,6 +85,29 @@ describe("Session", function () {
         expect(result.buildId).toEqual('100');
     });
     
+    it("sets the appdesc correctly when specified [--appdesc C:/path/bardescriptor.xml]", function () {
+        testUtils.mockResolve(path);
+
+        var data = {
+            args: [ 'C:/sampleApp/sample.zip' ],
+            appdesc: 'C:/path/bardescriptor.xml' //equivalent to [--appdesc C:/path/bardescriptor.xml]
+        },
+        result = session.initialize(data);
+
+        expect(result.appdesc).toEqual(path.normalize("C:/path/bardescriptor.xml"));
+    });
+    
+    it("sets the appdesc correctly when not specified", function () {
+        testUtils.mockResolve(path);
+
+        var data = {
+            args: [ 'C:/sampleApp/sample.zip' ]
+        },
+        result = session.initialize(data);
+
+        expect(result.appdesc).toBeUndefined();
+    });
+    
     it("sets the output directory correctly when specified with a relative path [-o myOutput]", function () {
         var bbwpDir = __dirname + "/../../../",
         data = {


### PR DESCRIPTION
To satisfy build and release, we need to use an existing bar-descriptor.xml instead of generating it. So I add "--appdesc path_to_bar_descriptor_file" to bbwp command. It is only for internal (B&R) use.

Fixes: https://github.com/blackberry/BB10-Webworks-Packager/issues/220
