### PR TITLE
Adds the ability to disable websecurity

### DIFF
--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -601,7 +601,8 @@ function init() {
                     bgColor = params.backgroundColor,
                     childBrowser = params.childBrowser,
                     formControl = params.formControl,
-                    orientation = params.orientation;
+                    orientation = params.orientation,
+                    websecurity = params.websecurity;
 
                 if (bgColor) {
                     //Convert bgColor to a number
@@ -630,6 +631,11 @@ function init() {
                     } else if (orientation !== "auto") {
                         throw localize.translate("EXCEPTION_INVALID_ORIENTATION_MODE", orientation);
                     }
+                }
+
+                if (websecurity && (typeof websecurity === "string") && (websecurity.toLowerCase() === "disable")) {
+                    widgetConfig.enableWebSecurity = false;
+                    logger.warn(localize.translate("WARNING_WEBSECURITY_DISABLED"));
                 }
             }
         }

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -180,6 +180,9 @@ var Localize = require("localize"),
         },
         "WARNING_ORIENTATION_DEPRECATED": {
             "en": "blackberry.app.orientation has been deprecated, please use blackberry.app instead"
+        },
+        "WARNING_WEBSECURITY_DISABLED": {
+            "en": "You have disabled all web security in this WebWorks application"
         }
 
     }, "", ""); // TODO maybe a bug in localize, must set default locale to "" in order get it to work

--- a/test/config.xml
+++ b/test/config.xml
@@ -24,6 +24,7 @@
       </feature>
     <feature id="blackberry.app" required="true" version="1.0.0.0">
         <param name="childBrowser" value="disable" />
+        <param name="websecurity" value="disable" />
     </feature>
     <feature id="blackberry.system" required="true" version="1.0.0.3"/>
     <access uri="http://www.somedomain1.com" subdomains="true">

--- a/test/unit/lib/config-parser.js
+++ b/test/unit/lib/config-parser.js
@@ -1312,5 +1312,50 @@ describe("config parser", function () {
             });
         });
 
+        describe('disabling WebSecurity', function () {
+
+            // { '@': { id: 'blackberry.app', required: true, version: '1.0.0.0' },
+            //   param: { '@': { name: 'childBrowser', value: 'disable' } } }
+
+
+            it("doesn't set enableWebSecurity to anything when param value is anything but disable", function () {
+                var data = testUtilities.cloneObj(testData.xml2jsConfig);
+                data.feature = { '@': { id: 'blackberry.app' },
+                    param: { '@': { name: 'websecurity', value: (new Date()).toString() } } };
+
+                mockParsing(data);
+
+                configParser.parse(configPath, session, extManager, function (configObj) {
+                    expect(configObj.enableWebSecurity).toBe(undefined);
+                    expect(logger.warn).not.toHaveBeenCalledWith(localize.translate("WARNING_WEBSECURITY_DISABLED"));
+                });
+            });
+
+            it("sets enableWebSecurity to false when value is disable", function () {
+                var data = testUtilities.cloneObj(testData.xml2jsConfig);
+                data.feature = { '@': { id: 'blackberry.app' },
+                    param: { '@': { name: 'websecurity', value: 'disable' } } };
+
+                mockParsing(data);
+
+                configParser.parse(configPath, session, extManager, function (configObj) {
+                    expect(configObj.enableWebSecurity).toBe(false);
+                    expect(logger.warn).toHaveBeenCalledWith(localize.translate("WARNING_WEBSECURITY_DISABLED"));
+                });
+            });
+
+            it("sets enableWebSecurity to false when value is disable case insensitive", function () {
+                var data = testUtilities.cloneObj(testData.xml2jsConfig);
+                data.feature = { '@': { id: 'blackberry.app' },
+                    param: { '@': { name: 'websecurity', value: 'DisAble' } } };
+
+                mockParsing(data);
+
+                configParser.parse(configPath, session, extManager, function (configObj) {
+                    expect(configObj.enableWebSecurity).toBe(false);
+                    expect(logger.warn).toHaveBeenCalledWith(localize.translate("WARNING_WEBSECURITY_DISABLED"));
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
Fixes blackberry/BB10-WebWorks-Framework#392

```
Reviewed By: NOBODY
Tested By: Tracy Li <tli@rim.com>

This commit parses a new param (websecurity) for blackberry.app
```

which has a possible value disable.
